### PR TITLE
Do not allow sending contact if subject and message not completed

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -58,7 +58,7 @@
     <string name="error_retrieving_host_information">Could not retrieve host information. Check your credentials and internet connection.</string>
     <string name="subject_hint">Enter subject here</string>
     <string name="message_hint">Enter message here</string>
-    <string name="message_validation_error">Both subject and message are obligatory.</string>
+    <string name="message_validation_error">Both subject and message are required.</string>
     <string name="sending_message">Sending message …</string>
     <string name="error_sending_message">Could not send message. Check your credentials and internet connection.</string>
     <string name="message_sent">Message sent successfully.</string>

--- a/src/fi/bitrite/android/ws/activity/HostContactActivity.java
+++ b/src/fi/bitrite/android/ws/activity/HostContactActivity.java
@@ -69,6 +69,7 @@ public class HostContactActivity extends RoboActivity {
 
 		if (Strings.isEmpty(subject) || Strings.isEmpty(message)) {
 			dialogHandler.alert(getResources().getString(R.string.message_validation_error));
+            return;
 		}
 
 		dialogHandler.showDialog(DialogHandler.HOST_CONTACT);


### PR DESCRIPTION
I noted in some testing that you could click the envelope "send" button on the contact form and it would try to send even though there was validation that failed (checking to see that the subject and message were populated). This patch fixes that. It also changes the string "obligatory" to the simpler "required".
