### PR TITLE
Get user uid key from a reliable location

### DIFF
--- a/src/fi/bitrite/android/ws/activity/HostInformationActivity.java
+++ b/src/fi/bitrite/android/ws/activity/HostInformationActivity.java
@@ -300,7 +300,7 @@ public class HostInformationActivity extends RoboActivity {
             try {
                 HttpHostInformation httpHostInfo = new HttpHostInformation();
                 HttpHostFeedback hostFeedback = new HttpHostFeedback();
-                int uid = hostInfo.getHost().getUid();
+                int uid = hostInfo.getId();
 
                 Host host = httpHostInfo.getHostInformation(uid);
                 ArrayList<Feedback> feedback = hostFeedback.getFeedback(uid);


### PR DESCRIPTION
Fixes #113 (Can't reload starred host) by getting the user uid from a working location.

Note that this is really a problem with the issues in #100, Consolidate Host and HostBriefInfo types. I think this quick change is fine for now, but the underlying complexity is the real problem. I didn't look farther, just found that the uid was easily available and used the close available version.
