### PR TITLE
Comment out Show on Map menu item since not implemented per #116

### DIFF
--- a/res/menu/host_information_menu.xml
+++ b/res/menu/host_information_menu.xml
@@ -6,10 +6,10 @@
         android:icon="@drawable/star"
         android:title="@string/star" />
 
-    <item
-        android:id="@+id/menuMap"
-        android:icon="@drawable/map"
-        android:title="@string/show_on_map" />
+    <!--<item-->
+        <!--android:id="@+id/menuMap"-->
+        <!--android:icon="@drawable/map"-->
+        <!--android:title="@string/show_on_map" />-->
     
     <item
         android:id="@+id/menuUpdate"

--- a/src/fi/bitrite/android/ws/activity/HostInformationActivity.java
+++ b/src/fi/bitrite/android/ws/activity/HostInformationActivity.java
@@ -349,9 +349,9 @@ public class HostInformationActivity extends RoboActivity {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
-            case R.id.menuMap:
-                showHostOnMap(null);
-                return true;
+//            case R.id.menuMap:
+//                showHostOnMap(null);
+//                return true;
             case R.id.menuStar:
                 showStarHostDialog(null);
                 return true;


### PR DESCRIPTION
As mentioned in #116 (Host Info's Show on Map Menu not implemented) I recommend that we just punt and remove the "Show on map" feature for this release. This commit just removes the menu item.
