### PR TITLE
Bump version name and code for next rev

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ android {
         release.setRoot('build-types/release')
     }
     defaultConfig {
-        versionName "1.4.0"
-        versionCode 20
+        versionName "1.4.1"
+        versionCode 21
     }
 }


### PR DESCRIPTION
Just bumps version so we don't forget it. 

I tagged the 1.4.0 release.
