### PR TITLE
Fix JSONException case in doSearch() - fixes #139

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -81,4 +81,6 @@
     <string name="distance_from_current">"%1$d %2$s from current location"</string>
     <string name="host_not_currently_available">(Not currently available)</string>
     <string name="host_currently_available">(Available for hosting)</string>
+    <string name="parsing_error">Error parsing response from server. Please report this search using the contact form at warmshowers.org.</string>
+    <string name="unknown_exception">Unknown error, please report to warmshowers.org contact form: %1$s</string>
 </resources>

--- a/src/fi/bitrite/android/ws/activity/ListSearchTabActivity.java
+++ b/src/fi/bitrite/android/ws/activity/ListSearchTabActivity.java
@@ -15,6 +15,9 @@ import android.widget.*;
 import android.widget.AdapterView.OnItemClickListener;
 import android.widget.TextView.OnEditorActionListener;
 import com.google.inject.Inject;
+
+import org.json.JSONException;
+
 import fi.bitrite.android.ws.R;
 import fi.bitrite.android.ws.WSAndroidApplication;
 import fi.bitrite.android.ws.host.Search;
@@ -172,11 +175,15 @@ public class ListSearchTabActivity extends RoboActivity {
         protected void onPostExecute(Object result) {
             dialogHandler.dismiss();
 
-            if (result instanceof Exception) {
-                // TODO: Improve error reporting with more specifics
-                int r = (result instanceof HttpException ? R.string.network_error : R.string.error_retrieving_host_information);
-                dialogHandler.alert(getResources().getString(r));
+            if (result instanceof HttpException) {
+                dialogHandler.alert(getResources().getString(R.string.network_error));
                 return;
+            } else if (result instanceof JSONException) {
+                dialogHandler.alert(getResources().getString(R.string.parsing_error));
+                return;
+            } else if (result instanceof Exception) {
+                dialogHandler.alert(getResources().getString(R.string.unknown_exception, result.toString()));
+
             }
 
             listSearchHosts = (ArrayList<HostBriefInfo>) result;

--- a/src/fi/bitrite/android/ws/host/Search.java
+++ b/src/fi/bitrite/android/ws/host/Search.java
@@ -1,12 +1,15 @@
 package fi.bitrite.android.ws.host;
 
+import org.json.JSONException;
+
 import java.util.List;
 
 import fi.bitrite.android.ws.activity.model.HostInformation;
 import fi.bitrite.android.ws.model.HostBriefInfo;
+import fi.bitrite.android.ws.util.http.HttpException;
 
 public interface Search {
     
-    public List<HostBriefInfo> doSearch();
+    public List<HostBriefInfo> doSearch() throws HttpException, JSONException;
 
 }


### PR DESCRIPTION
This actually was pretty bad - it was failing with 'no internet connection' when
there were no hosts, because it was always assuming that there was an
accounts object, and when there were no hits, it wasn't there.

This also improves exception handling in that area quite a bit, reporting more info for unexpected cases and asking user to report the problem. We might be better to report things like this to GA, but that's for the future :-)
