### PR TITLE
Fix up build.gradle dependencies for newer Android Studio

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,10 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.2'
+        classpath 'com.android.tools.build:gradle:+'
     }
 }
 apply plugin: 'com.android.application'
-
 repositories {
     mavenCentral()
 }


### PR DESCRIPTION
I don't think this tiny change should affect earlier versions or IntelliJ either.

```
Update gradle plugin version

This went crazy with 1.x upgrade to Android Studio, apparently
for no reason. I don't know why we should specify it more
carefully than this.

The actual error was
The project is using an unsupported version of the Android Gradle plug-in
which is really hard to track down to just a classpath in the
build.gradle!
```
