### PR TITLE
Fix backspace-on-auth problem by creating tabs later, fixes #128

### DIFF
--- a/src/fi/bitrite/android/ws/activity/MainActivity.java
+++ b/src/fi/bitrite/android/ws/activity/MainActivity.java
@@ -8,6 +8,7 @@ import android.app.Dialog;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Parcelable;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -24,8 +25,8 @@ import fi.bitrite.android.ws.auth.NoAccountException;
 
 import java.util.ArrayList;
 
-public class MainActivity extends RoboTabActivity {
-
+public class MainActivity extends RoboTabActivity  {
+    
     private Dialog splashDialog;
 
     // a host is "stashed" when moving from e.g. the host information activity directly
@@ -34,6 +35,7 @@ public class MainActivity extends RoboTabActivity {
     private int stashedHostId;
     private ArrayList<Parcelable> stashedFeedback;
     private static final String TAG = "MainActivity";
+    private boolean tabsCreated = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -42,8 +44,9 @@ public class MainActivity extends RoboTabActivity {
         handleFirstRun();
 
         setContentView(R.layout.main);
-        setupTabs();
-        setupCredentials();
+        if (setupCredentials()) {
+            setupTabs();  // If creds already there, set up tabs now, else wait until login
+        }
 
         if (savedInstanceState != null) {
             boolean splash = savedInstanceState.getBoolean("splash", false);
@@ -52,9 +55,9 @@ public class MainActivity extends RoboTabActivity {
             }
         }
     }
-
+    
     /**
-     * New for version code 10. We want to store some additional data with the
+     * New for version code 10. We want to store some additional data with the 
      * account, so we need to remove the old one.
      */
     private void handleFirstRun() {
@@ -64,32 +67,48 @@ public class MainActivity extends RoboTabActivity {
                 AccountManager accountManager = AccountManager.get(this);
                 Account oldAccount = AuthenticationHelper.getWarmshowersAccount();
                 accountManager.removeAccount(oldAccount, null, null);
-            } catch (NoAccountException e) {
+            }
+            
+            catch (NoAccountException e) {
                 // OK, so there was no account - fine
             }
-            getSharedPreferences("PREFERENCE", MODE_PRIVATE).edit().putBoolean("v10update", false).commit();
+            getSharedPreferences("PREFERENCE", MODE_PRIVATE).edit().putBoolean("v10update", false).commit();            
         }
     }
 
-    private void setupCredentials() {
+    /**
+     *
+     * @return
+     *   true if we already have an account set up and it's working
+     *   false if we have to wait for the auth screen to process
+     */
+    private boolean setupCredentials() {
         try {
             AuthenticationHelper.getWarmshowersAccount();
-        } catch (NoAccountException e) {
+            return true;
+        }
+        catch (NoAccountException e) {
             startAuthenticatorActivity(new Intent(MainActivity.this, AuthenticatorActivity.class));
+            return false; // Wait to set up tabs until auth is done
         }
     }
-
+    
     private void startAuthenticatorActivity(Intent i) {
         i.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
         overridePendingTransition(0, 0);
         startActivityForResult(i, 0);
     }
 
+    @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
+        if (resultCode == AuthenticatorActivity.RESULT_OK) {
+            setupTabs();
+            return;
+        }
         if (initialAccountCreation(intent)) {
             if (resultCode == RESULT_CANCELED) {
                 Toast.makeText(getApplicationContext(), R.string.need_account, Toast.LENGTH_LONG).show();
-                finishWithDelay();
+                finish();
             } else if (resultCode == AuthenticatorActivity.RESULT_AUTHENTICATION_FAILED) {
                 Toast.makeText(getApplicationContext(), R.string.authentication_failed, Toast.LENGTH_LONG).show();
                 startAuthenticatorActivity(new Intent(MainActivity.this, AuthenticatorActivity.class));
@@ -101,63 +120,60 @@ public class MainActivity extends RoboTabActivity {
             }
         }
     }
-
+        
     private boolean initialAccountCreation(Intent intent) {
         return intent.getBooleanExtra(AuthenticatorActivity.PARAM_INITIAL_AUTHENTICATION, true);
     }
 
-    private void finishWithDelay() {
-        new Thread(new Runnable() {
-            public void run() {
-                try {
-                    Thread.sleep(3000);
-                } catch (Exception e) {
-                }
-                finish();
-            }
-        }).start();
-    }
 
     private void setupTabs() {
+        if (tabsCreated) {
+            return;
+        }
         TabHost tabHost = getTabHost();
         addTab(tabHost, "tab_map", R.drawable.tab_icon_map, new Intent(this, Maps2Activity.class));
         addTab(tabHost, "tab_list", R.drawable.tab_icon_list, new Intent(this, ListSearchTabActivity.class));
         addTab(tabHost, "tab_starred", R.drawable.tab_icon_starred, new Intent(this, StarredHostTabActivity.class));
         addTab(tabHost, "tab_messages", R.drawable.tab_icon_messages, new Intent(this, MessagesTabActivity.class));
+        tabsCreated = true;
     }
 
     private void addTab(TabHost tabHost, String tabSpec, int icon, Intent content) {
         tabHost.addTab(tabHost.newTabSpec(tabSpec).setIndicator("", getResources().getDrawable(icon)).setContent(content));
     }
-
+    
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.main_menu, menu);
         return true;
-    }
-
+    }   
+    
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
-            case R.id.menuAccount:
-                startAuthenticationActivityForExistingAccount();
-                return true;
-            case R.id.menuSettings:
-                startSettingsActivity();
-                return true;
-            case R.id.menuAbout:
-                showAboutDialog();
-                return true;
-            default:
-                return super.onOptionsItemSelected(item);
+        case R.id.menuAccount:
+            startAuthenticationActivityForExistingAccount();
+            return true;
+        case R.id.menuSettings:
+            startSettingsActivity();
+            return true;
+        case R.id.menuAbout:
+            showAboutDialog();
+            return true;
+        default:
+            return super.onOptionsItemSelected(item);
         }
     }
 
     private void startAuthenticationActivityForExistingAccount() {
         Intent i = new Intent(MainActivity.this, AuthenticatorActivity.class);
-        Account account = AuthenticationHelper.getWarmshowersAccount();
-        i.putExtra(AuthenticatorActivity.PARAM_USERNAME, account.name);
+        try {
+            Account account = AuthenticationHelper.getWarmshowersAccount();
+            i.putExtra(AuthenticatorActivity.PARAM_USERNAME, account.name);
+        } catch (NoAccountException e) {
+            // We have no account, so forget it.
+        }
         startAuthenticatorActivity(i);
     }
 
@@ -169,9 +185,9 @@ public class MainActivity extends RoboTabActivity {
     private void showAboutDialog() {
         splashDialog = new Dialog(this, R.style.about_dialog);
         splashDialog.setContentView(R.layout.about);
-        TextView versionTextView = (TextView) splashDialog.findViewById(R.id.app_version);
+        TextView versionTextView = (TextView)splashDialog.findViewById(R.id.app_version);
         versionTextView.setText(getString(R.string.app_version, BuildConfig.VERSION_NAME));
-        TextView googleDetails = (TextView) splashDialog.findViewById(R.id.txtAboutDetailsGoogle);
+        TextView googleDetails = (TextView)splashDialog.findViewById(R.id.txtAboutDetailsGoogle);
         String licenseInfo = GooglePlayServicesUtil.getOpenSourceSoftwareLicenseInfo(this);
         if (licenseInfo != null) {
             // licenseInfo is a bit of a mess (coming directly from google)
@@ -194,7 +210,7 @@ public class MainActivity extends RoboTabActivity {
     public void switchTab(int tab) {
         getTabHost().setCurrentTab(tab);
     }
-
+    
     public void stashHost(Intent data, int stashedFrom) {
         stashedHost = data.getParcelableExtra("host");
         stashedHostId = data.getIntExtra("id", 0);
@@ -204,7 +220,7 @@ public class MainActivity extends RoboTabActivity {
     public boolean hasStashedHost() {
         return stashedHost != null;
     }
-
+    
     public Intent popStashedHost(Intent i) {
         i.putExtra("host", stashedHost);
         i.putExtra("id", stashedHostId);

--- a/src/fi/bitrite/android/ws/auth/http/HttpAuthenticator.java
+++ b/src/fi/bitrite/android/ws/auth/http/HttpAuthenticator.java
@@ -4,6 +4,7 @@ import android.accounts.Account;
 import android.accounts.AccountManager;
 import android.accounts.AuthenticatorException;
 import android.accounts.OperationCanceledException;
+import android.util.Log;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -39,12 +40,14 @@ import java.util.List;
 public class HttpAuthenticator {
 
     private final String wsUserAuthUrl = GlobalInfo.warmshowersBaseUrl + "/services/rest/user/login";
+    private final String wsUserLogoutUrl = GlobalInfo.warmshowersBaseUrl + "/services/rest/user/logout";
     private final String wsUserAuthTestUrl = GlobalInfo.warmshowersBaseUrl + "/search/wsuser";
 
     private String username;
     private String authtoken;
     private String mCookieSessId = "";
     private String mCookieSessName = "";
+    private static final String TAG = "HttpAuthenticator";
 
     /**
      * Load a page in order to see if we are authenticated
@@ -94,6 +97,14 @@ public class HttpAuthenticator {
         HttpClient client = HttpUtils.getDefaultClient();
         HttpContext httpContext = HttpSessionContainer.INSTANCE.getSessionContext();
         int userId = 0;
+
+        try {
+            HttpPost post = new HttpPost(wsUserLogoutUrl);
+            HttpResponse response = client.execute(post, httpContext);
+        } catch (Exception e) {
+            Log.e(TAG, "Exception on logout: " + e.toString());
+            // We don't care a lot about this, as we were just trying to ensure clean login.
+        }
 
         try {
             List<NameValuePair> credentials = generateCredentialsForPost(username, password);


### PR DESCRIPTION
This should fix #128 (hitting backspace when on initial authentication screen) - the basic approach is to wait to build the tab activities until after we're authenticated.
