### PR TITLE
Refactor AuthenticationHelper and use Account for storing cookie info

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -101,6 +101,6 @@
     <string name="save">Save</string>
     <string name="star_this_host">Star this host</string>
     <string name="unstar_this_host">Unstar this host</string>
-    <string name="no_account"><![CDATA[Account information has not been configured. Settings->Account]]></string>
+    <string name="no_account">Account information has not been configured. Settings -> Account</string>
     <string name="http_server_access_failure">Failed communicating with server, please check your internet connection</string>
 </resources>

--- a/src/fi/bitrite/android/ws/WSAndroidApplication.java
+++ b/src/fi/bitrite/android/ws/WSAndroidApplication.java
@@ -1,5 +1,7 @@
 package fi.bitrite.android.ws;
 
+import android.accounts.Account;
+import android.accounts.AccountManager;
 import android.app.Application;
 import android.content.Context;
 import android.preference.PreferenceManager;
@@ -7,6 +9,8 @@ import com.google.android.gms.analytics.GoogleAnalytics;
 import com.google.android.gms.analytics.Tracker;
 
 import java.util.HashMap;
+
+import fi.bitrite.android.ws.util.GlobalInfo;
 
 
 public class WSAndroidApplication extends Application {
@@ -55,5 +59,6 @@ public class WSAndroidApplication extends Application {
     public static Context getAppContext() {
         return WSAndroidApplication.mContext;
     }
+
 
 }

--- a/src/fi/bitrite/android/ws/activity/MessagesTabActivity.java
+++ b/src/fi/bitrite/android/ws/activity/MessagesTabActivity.java
@@ -49,14 +49,8 @@ public class MessagesTabActivity extends RoboActivity implements View.OnClickLis
         viewMessagesOnSite.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                // Getting the uid out of the stashed cookie info is pretty sad. Maybe @jstaffans
-                // can show me how to get it from the account object.
-                SharedPreferences authInfo = getSharedPreferences("auth_cookie", 0);
-                if (authInfo.contains("account_uid")) {
-                    int uid = authInfo.getInt("account_uid", 0);
-                    String url = GlobalInfo.warmshowersBaseUrl + "/user/" + uid + "/messages";
-                    WebViewActivity.viewOnSite(MessagesTabActivity.this, url, getString(R.string.messages_on_site));
-                }
+                String url = GlobalInfo.warmshowersBaseUrl + "/user/" + AuthenticationHelper.getAccountUid() + "/messages";
+                WebViewActivity.viewOnSite(MessagesTabActivity.this, url, getString(R.string.messages_on_site));
             }
         });
     }

--- a/src/fi/bitrite/android/ws/activity/WebViewActivity.java
+++ b/src/fi/bitrite/android/ws/activity/WebViewActivity.java
@@ -15,10 +15,14 @@ import android.webkit.WebView;
 
 import android.webkit.CookieManager;
 import android.webkit.WebViewClient;
+import android.widget.Toast;
 
 import java.net.URI;
 
 import fi.bitrite.android.ws.R;
+import fi.bitrite.android.ws.WSAndroidApplication;
+import fi.bitrite.android.ws.auth.AuthenticationHelper;
+import fi.bitrite.android.ws.auth.NoAccountException;
 import fi.bitrite.android.ws.util.GlobalInfo;
 
 public class WebViewActivity extends Activity {
@@ -49,18 +53,17 @@ public class WebViewActivity extends Activity {
         String url = this.getIntent().getDataString();
         setTitle(this.getIntent().getStringExtra("webview_title"));
 
-        SharedPreferences cookieInfo = getSharedPreferences("auth_cookie", 0);
-        if (cookieInfo.contains("cookie_sess_id")) {
-            String sessId = cookieInfo.getString("cookie_sess_id", "");
-            String sessName = cookieInfo.getString("cookie_sess_name", "");
-
-            CookieSyncManager.createInstance(this);
-            CookieManager cookieManager = CookieManager.getInstance();
-
-            String cookieString = sessName + "=" + sessId + "; domain=" + GlobalInfo.warmshowersDomain;
-            cookieManager.setCookie(GlobalInfo.warmshowersBaseUrl, cookieString);
-            CookieSyncManager.getInstance().sync();
+        CookieSyncManager.createInstance(this);
+        CookieManager cookieManager = CookieManager.getInstance();
+        String cookieString = "";
+        try {
+            cookieString = AuthenticationHelper.getAccountCookie();
+        } catch (NoAccountException e) {
+            Toast.makeText(this, R.string.no_account, Toast.LENGTH_SHORT);
+            // We'll continue because they *could* just log in.
         }
+        cookieManager.setCookie(GlobalInfo.warmshowersBaseUrl, cookieString);
+        CookieSyncManager.getInstance().sync();
 
         mWebView.loadUrl(url);
 

--- a/src/fi/bitrite/android/ws/api/RestClient.java
+++ b/src/fi/bitrite/android/ws/api/RestClient.java
@@ -1,10 +1,10 @@
 package fi.bitrite.android.ws.api;
 
-import android.accounts.AccountsException;
 import android.content.Context;
 import android.widget.Toast;
 
 import fi.bitrite.android.ws.R;
+import fi.bitrite.android.ws.auth.NoAccountException;
 import fi.bitrite.android.ws.auth.http.HttpAuthenticationFailedException;
 import fi.bitrite.android.ws.auth.http.HttpSessionContainer;
 import fi.bitrite.android.ws.util.Tools;
@@ -62,22 +62,24 @@ public class RestClient extends HttpReader {
         return json;
     }
 
-    public static void reportError(Context context, Object e) {
-        if (e instanceof Exception) {
+    public static void reportError(Context context, Object obj) {
+        if (obj instanceof Exception) {
             int rId = 0;
-            if (e instanceof AccountsException) {
+            if (obj instanceof NoAccountException) {
                 rId = R.string.no_account;
-            } else if (e instanceof HttpAuthenticationFailedException) {
+            } else if (obj instanceof HttpAuthenticationFailedException) {
                 rId = R.string.authentication_failed;
-            } else if (e instanceof HttpException) {
+            } else if (obj instanceof HttpException) {
                 rId = R.string.http_server_access_failure;
-            } else if (e instanceof IOException) {
+            } else if (obj instanceof IOException) {
                 rId = R.string.io_error;
             } else {
                 // Unexpected error
                 rId = R.string.http_unexpected_failure;
             }
-            Tools.gaReportException(context, "Exception in RestClient: ", e.toString());
+            Exception e = (Exception)obj;
+            String exceptionDescription = e.toString() + " Message:" + e.getMessage() + " Cause: " + e.getCause().toString();
+            Tools.gaReportException(context, "RestClient Exception: ", exceptionDescription);
 
             Toast.makeText(context, rId, Toast.LENGTH_LONG).show();
         }

--- a/src/fi/bitrite/android/ws/auth/AuthenticationHelper.java
+++ b/src/fi/bitrite/android/ws/auth/AuthenticationHelper.java
@@ -2,11 +2,28 @@ package fi.bitrite.android.ws.auth;
 
 import android.accounts.Account;
 import android.accounts.AccountManager;
+import android.accounts.AuthenticatorException;
+import android.accounts.OperationCanceledException;
+
+import java.io.IOException;
+
 import fi.bitrite.android.ws.WSAndroidApplication;
+import fi.bitrite.android.ws.util.GlobalInfo;
 
 public class AuthenticationHelper {
+    public static final String KEY_SESSION_NAME = "session_name";
+    public static final String KEY_SESSID = "sessid";
+    public static final String KEY_USERID = "userid";
 
-    public static Account getWarmshowersAccount() {
+    public static Account createNewAccount(String username, String password) {
+        AccountManager accountManager = AccountManager.get(WSAndroidApplication.getAppContext());
+        Account account = new Account(username, AuthenticationService.ACCOUNT_TYPE);
+        accountManager.addAccountExplicitly(account, null, null);
+        accountManager.setAuthToken(account, AuthenticationService.ACCOUNT_TYPE, password);
+        return account;
+    }
+
+    public static Account getWarmshowersAccount() throws NoAccountException {
         AccountManager accountManager = AccountManager.get(WSAndroidApplication.getAppContext());
         Account[] accounts = accountManager.getAccountsByType(AuthenticationService.ACCOUNT_TYPE);
 
@@ -17,4 +34,44 @@ public class AuthenticationHelper {
         return accounts[0];
     }
 
+    public static String getAccountCookie() {
+        AccountManager accountManager = AccountManager.get(WSAndroidApplication.getAppContext());
+        Account account = getWarmshowersAccount();
+        String session_name = accountManager.getUserData(account, KEY_SESSION_NAME);
+        String sessid = accountManager.getUserData(account, KEY_SESSID);
+        String cookieString = session_name + "=" + sessid + "; domain=" + GlobalInfo.warmshowersCookieDomain;
+        return cookieString;
+    }
+
+    public static int getAccountUid() {
+        AccountManager accountManager = AccountManager.get(WSAndroidApplication.getAppContext());
+        Account account = getWarmshowersAccount();
+        String uid = accountManager.getUserData(account, KEY_USERID);
+        return Integer.parseInt(uid);
+    }
+
+    public static String getAccountUsername() {
+        Account account = getWarmshowersAccount();
+        String username = account.name;
+        return username;
+    }
+
+    public static String getAccountPassword() throws OperationCanceledException, IOException, AuthenticatorException {
+        AccountManager accountManager = AccountManager.get(WSAndroidApplication.getAppContext());
+        Account account = getWarmshowersAccount();
+
+        // authToken is here instead of password for legacy reasons, and doesn't make sense to
+        // break all existing accounts by changing it.
+        String password = accountManager.blockingGetAuthToken(account, AuthenticationService.ACCOUNT_TYPE, true);
+        return password;
+    }
+
+    public static void addCookieInfo(String cookieSessionName, String cookieSessionId, int userId) {
+        AccountManager accountManager = AccountManager.get(WSAndroidApplication.getAppContext());
+        Account account = getWarmshowersAccount();
+
+        accountManager.setUserData(account, KEY_SESSION_NAME, cookieSessionName);
+        accountManager.setUserData(account, KEY_SESSID, cookieSessionId);
+        accountManager.setUserData(account, KEY_USERID, String.valueOf(userId));
+    }
 }

--- a/src/fi/bitrite/android/ws/util/GlobalInfo.java
+++ b/src/fi/bitrite/android/ws/util/GlobalInfo.java
@@ -4,6 +4,6 @@ package fi.bitrite.android.ws.util;
  * Provide basic info that may not be accessible any other way.
  */
 public class GlobalInfo {
-    public static final String warmshowersDomain = "warmshowers.org";
+    public static final String warmshowersCookieDomain = ".warmshowers.org";
     public static final String warmshowersBaseUrl = "https://www.warmshowers.org";
 }


### PR DESCRIPTION
This fixes #110 (webview to display profile on site) _again_. We had a problem with it losing the current cookie and failing authentication.

This is a pretty disruptive PR though, as I ended up doing some fairly valuable, but again disruptive, things. I think they're all worth doing.
- Moved all account access into the AuthenticationHelper class, so things get done the same wherever they're done from.
- Moved the storage of the cookie into the Account object; it turned out that was a pretty easy thing to do.

I don't think we have to retest on lower APIs, but unfortunately this should get another whole round on:
- Login
- Delete account in settings while app is up
- Change password on site while app is running
- Change login credentials while app is running (going to Menu->Account)
- After those, try to access the "view on site" - both the view profile and the leave feedback should result the same.

I'm pretty sure it's a step forward. 
