### PR TITLE
Add French translation for distance units

### DIFF
--- a/res/values-fr/arrays.xml
+++ b/res/values-fr/arrays.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+
+    <string-array name="distanceUnits">
+        <item name="km">Kilomètres</item>
+        <item name="mi">Miles</item>
+    </string-array>
+    
+    <string-array name="distanceUnitValues">
+        <item name="km">km</item>
+        <item name="mi">mi</item>
+    </string-array>
+
+</resources>


### PR DESCRIPTION
I'm not sure if it is best practice to duplicate each files that have strings to translate in 'values/' into their appropriate 'values-xx/' localized folders, or to keep all translations into strings.xml (I think that's the behavior of AS' Translation Editor). I think separate files are cleaner and it's working. 
(ps. Actually these being arrays my reflexion might not make sense. But I've seen this AS behavior for strings in 'google_maps_api.xml'.)