### PR TITLE
Add jitpack.io maven dep for material-dialogs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ repositories {
 
     repositories {
         maven { url 'https://dl.bintray.com/drummer-aidan/maven' }
+        maven { url "https://jitpack.io" }
     }
 }
 


### PR DESCRIPTION
I ran into a gradle dependency issue with material-dialog while setting up the project locally.
Looks like we need to add the jitpack.io maven repo to build.gradle
https://github.com/afollestad/material-dialogs#gradle-dependency

@rfay 