### PR TITLE
Fix logic for recreating HostInformationActivity

### DIFF
--- a/app/src/main/java/fi/bitrite/android/ws/activity/model/HostInformation.java
+++ b/app/src/main/java/fi/bitrite/android/ws/activity/model/HostInformation.java
@@ -32,7 +32,7 @@ public class HostInformation {
         final Host host = savedInstanceState.getParcelable("host");
         final ArrayList<Feedback> feedback = savedInstanceState.getParcelableArrayList("feedback");
         final int id = savedInstanceState.getInt("id");
-        final boolean starred = dao.isHostStarred(id, host.getName());
+        final boolean starred = dao.isHostStarred(id);
 
         return new HostInformation(host, feedback, id, starred);
     }
@@ -41,7 +41,7 @@ public class HostInformation {
         final Host host = (Host) i.getParcelableExtra("host");
         final int id = i.getIntExtra("id", NO_ID);
         final ArrayList<Feedback> feedback = i.getParcelableArrayListExtra("feedback");
-        final boolean starred = dao.isHostStarred(id, host.getName());
+        final boolean starred = dao.isHostStarred(id);
 
         return new HostInformation(host, feedback, id, starred);
     }

--- a/app/src/main/java/fi/bitrite/android/ws/persistence/StarredHostDao.java
+++ b/app/src/main/java/fi/bitrite/android/ws/persistence/StarredHostDao.java
@@ -21,7 +21,7 @@ public interface StarredHostDao {
 
     public void update(int id, String name, Host host, List<Feedback> feedback);
 
-    public boolean isHostStarred(int id, String name);
+    public boolean isHostStarred(int id);
 
     public void open();
 

--- a/app/src/main/java/fi/bitrite/android/ws/persistence/impl/StarredHostDaoImpl.java
+++ b/app/src/main/java/fi/bitrite/android/ws/persistence/impl/StarredHostDaoImpl.java
@@ -11,12 +11,9 @@ import fi.bitrite.android.ws.model.Host;
 import fi.bitrite.android.ws.model.HostBriefInfo;
 import fi.bitrite.android.ws.persistence.StarredHostDao;
 
-import java.lang.reflect.Array;
 import java.lang.reflect.Type;
-import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 
 public class StarredHostDaoImpl implements StarredHostDao {
@@ -159,7 +156,7 @@ public class StarredHostDaoImpl implements StarredHostDao {
         insert(id, name, host, feedback);
     }
 
-    public boolean isHostStarred(int id, String name) {
+    public boolean isHostStarred(int id) {
         return (getHost(id) != null);
     }
 }


### PR DESCRIPTION
Fixes #243

The logic for onCreate didn't account for recreating the activity, which happens when you change the screen orientation, so I rewrote to hopefully be clearer.

Also removed the unused `String name` param from `StarredHostDao.isHostStarred` and cleaned up some unused imports.

On a side note, we could really use some basic automated testing and should probably update our project structure to the Gradle recommended structure, which would make testing easy without any extra configuration. http://tools.android.com/tech-docs/new-build-system/user-guide#TOC-Project-Structure

@rfay 