### PR TITLE
Fixes issues in build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,7 @@ repositories {
     repositories {
         maven { url 'https://dl.bintray.com/drummer-aidan/maven' }
         maven { url "https://jitpack.io" }
+        maven { url "https://maven.google.com" }
     }
 }
 
@@ -19,18 +20,21 @@ repositories {
 
 dependencies {
     compile files('libs/parcelgen.jar')  // Can't find for maven/gradle
-    compile 'com.google.code.gson:gson:2.1'
+    compile 'com.google.code.gson:gson:2.7'
     compile 'com.google.maps.android:android-maps-utils:0.3.4'
-    compile 'com.google.guava:guava:18.0'
-    compile 'com.google.android.gms:play-services:6.5.87'
-    compile 'com.android.support:appcompat-v7:22.1.1'
-    compile 'com.android.support:support-v4:22.1.0'
-    compile 'com.android.support:cardview-v7:21.0.+'
-    compile 'com.afollestad:material-dialogs:0.7.4.2' // https://github.com/afollestad/material-dialogs
+    compile 'com.google.guava:guava:20.0'
+    compile 'com.google.android.gms:play-services-maps:11.0.4'
+    compile 'com.google.android.gms:play-services-analytics:11.0.4'
+    compile 'com.google.android.gms:play-services-location:11.0.4'
+    compile 'com.android.support:appcompat-v7:25.3.1'
+    compile 'com.android.support:support-v4:25.3.1'
+    compile 'com.android.support:cardview-v7:25.3.1'
+    compile 'com.afollestad.material-dialogs:commons:0.9.4.7'
+    compile 'org.jbundle.util.osgi.wrapped:org.jbundle.util.osgi.wrapped.org.apache.http.client:4.1.2'
 }
 
 android {
-    buildToolsVersion "22.0.1"
+    buildToolsVersion '25.0.0'
 
     sourceSets {
         // Move the build types to build-types/<type>
@@ -45,8 +49,8 @@ android {
     defaultConfig {
         versionName "1.5.1beta1"
         versionCode 38
-        minSdkVersion 11
-        compileSdkVersion 22
-        targetSdkVersion 22
+        minSdkVersion 14
+        compileSdkVersion 26
+        targetSdkVersion 26
     }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     compile 'com.android.support:cardview-v7:25.3.1'
     compile 'com.afollestad.material-dialogs:commons:0.9.4.7'
     compile 'org.jbundle.util.osgi.wrapped:org.jbundle.util.osgi.wrapped.org.apache.http.client:4.1.2'
+    compile 'junit:junit:4.12'
 }
 
 android {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Fri Sep 22 14:22:44 PDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
The current version of build.gradle does trigger errors due to unavailable libraries especially  0.7.4.2 version of `com.afollestad:material-dialogs:0.7.4.2` which is no longer available to download.

This commit fix the above mentioned issue, also it updates all other libraries to the latest version and also upgrade Gradle.
Also, From version 6.5, you can instead selectively compile Google Play service APIs into your app which leads to smaller APK size, this commit downloads `Google Maps`, `Analytics` and `Location` from Play services

I have tested these changes and they're safe to commit