### PR TITLE
Avoid unneccessary calls to UserFragment::updateUserViewContent. Fixes #287.

### DIFF
--- a/app/src/main/java/fi/bitrite/android/ws/ui/UserFragment.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/UserFragment.java
@@ -156,10 +156,10 @@ public class UserFragment extends BaseFragment {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(isFavorite -> {
                     saveUserIfFavorite();
-
                     mCkbFavorite.setChecked(isFavorite);
                     mImgFavorite.setColorFilter(isFavorite ? mFavoritedColor : mNonFavoritedColor);
                 }));
+
         getResumePauseDisposable().add(mLastUserInfoLoadResult
                 .filter(result -> !result.isHandled)
                 .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/fi/bitrite/android/ws/ui/UserFragment.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/UserFragment.java
@@ -169,6 +169,9 @@ public class UserFragment extends BaseFragment {
                     mDownloadUserInfoProgressDisposable.dispose();
                     if (result.throwable != null) {
                         HttpErrorHelper.showErrorToast(getContext(), result.throwable);
+                        if (mUser.getValue() == null) {
+                            getFragmentManager().popBackStack();
+                        }
                     }
                 }));
     }

--- a/app/src/main/res/layout/fragment_user.xml
+++ b/app/src/main/res/layout/fragment_user.xml
@@ -13,8 +13,7 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:paddingBottom="20dp"
-        android:visibility="gone">
+        android:paddingBottom="20dp" >
 
         <RelativeLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
This should fix #287 by initializing `mUser` with `BehaviourSubject.create()`. 

I also did some small clean up in `Repository.java`. As @saemy already stated in a comment, some checks were unneccessary. As the  `loadFromNetwork` observable is always added last to the observables list, it emits its results last as well (see http://reactivex.io/documentation/operators/concat.html).

Last not least, immediately return to the last fragment on the stack if an exception is thrown in the process of getting the user's data. I think this is a good idea from an user's perspective, but have no problem to revert that change or move it to another PR.