### PR TITLE
Make expired auth token renewals reentrant

### DIFF
--- a/app/src/main/java/fi/bitrite/android/ws/auth/AccountManager.java
+++ b/app/src/main/java/fi/bitrite/android/ws/auth/AccountManager.java
@@ -29,6 +29,7 @@ import io.reactivex.Maybe;
 import io.reactivex.MaybeObserver;
 import io.reactivex.Observable;
 import io.reactivex.Single;
+import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Function;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.BehaviorSubject;
@@ -224,7 +225,7 @@ public class AccountManager {
                 try {
                     Bundle result = tokenFuture.getResult();
 
-                    handleIntentInBundle(result)
+                    Disposable unused = handleIntentInBundle(result)
                             .subscribe(result2 -> {
                                 String authTokenStr = result2.getString(
                                         android.accounts.AccountManager.KEY_AUTHTOKEN);

--- a/app/src/main/java/fi/bitrite/android/ws/auth/AuthToken.java
+++ b/app/src/main/java/fi/bitrite/android/ws/auth/AuthToken.java
@@ -23,4 +23,11 @@ public class AuthToken {
 
         return new AuthToken(name, id);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return other != null
+               && other instanceof AuthToken
+               && toString().equals(other.toString());
+    }
 }

--- a/app/src/main/java/fi/bitrite/android/ws/ui/MainActivity.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/MainActivity.java
@@ -35,7 +35,6 @@ import dagger.android.AndroidInjection;
 import dagger.android.DispatchingAndroidInjector;
 import dagger.android.support.HasSupportFragmentInjector;
 import fi.bitrite.android.ws.R;
-import fi.bitrite.android.ws.api.AuthenticationController;
 import fi.bitrite.android.ws.auth.AccountManager;
 import fi.bitrite.android.ws.di.account.AccountComponent;
 import fi.bitrite.android.ws.di.account.AccountComponentManager;
@@ -368,7 +367,6 @@ public class MainActivity extends AppCompatActivity implements HasSupportFragmen
     private final AccountHelper mAccountHelper = new AccountHelper();
     public class AccountHelper {
         @Inject Account mAccount;
-        @Inject AuthenticationController mAuthenticationController;
         @Inject DispatchingAndroidInjector<Fragment> mDispatchingAndroidInjector;
         @Inject LoggedInUserHelper mLoggedInUserHelper;
         @Inject MessageRepository mMessageRepository;


### PR DESCRIPTION
If multiple API requests were in-flight and failing because of an
expired auth token, that auth token was marked as expired multiple times
which resulted in the login activity being shown for each such call.

Also, the AuthenticationController is now fully per-account. It was
already in the account scope but always handled the current account.