### PR TITLE
Remove unused deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,23 +19,22 @@ If you find something within the code you’d like to see changed for performanc
 * More translations (see [#234](https://github.com/warmshowers/wsandroid/issues/234))
   * We currently support English, German, French, and Spanish
   * Currently, we do not use Transifex, POEditor, or other services but as soon as someone would like to help, we’re going to look into it
-  
+
 * Tests of any kind—UI tests, unit tests, integration tests, you name it
 
 ## OSS libraries in use (aka, Thank You!)
 
 Without these libraries, our lives would be a whole lot more difficult. So thank you all for developing and maintaining those fine pieces of software!
 
-* [Dagger2](https://github.com/google/dagger)
+* [AssertJ](https://github.com/joel-costigliola/assertj-core)
 * [ButterKnife](https://github.com/JakeWharton/butterknife)
-* [Material Dialogs](https://github.com/afollestad/material-dialogs)
+* [Dagger2](https://github.com/google/dagger)
 * [Gson](https://github.com/google/gson)
-* [Guava](https://github.com/google/guava)
-* [Android Maps Utils](https://github.com/googlemaps/android-maps-utils)
+* [JUnit](https://github.com/junit-team/junit4)
+* [Osmdroid](https://osmdroid.github.io/osmdroid)
+* [OSMBonusPack](https://github.com/MKergall/osmbonuspack)
 * [Picasso](https://github.com/square/picasso)
 * [Retrofit 2](https://github.com/square/retrofit)
-* [RxJava 2](https://github.com/ReactiveX/RxJava)
-* [RxAndroid](https://github.com/ReactiveX/RxAndroid)
-* [AssertJ](https://github.com/joel-costigliola/assertj-core)
 * [Robolectric](https://github.com/robolectric/robolectric)
-* [JUnit](https://github.com/junit-team/junit4)
+* [RxAndroid](https://github.com/ReactiveX/RxAndroid)
+* [RxJava 2](https://github.com/ReactiveX/RxJava)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -113,7 +113,6 @@ ext {
     gsonVersion = '2.8.1'
     jsonVersion = '20170516'
     junitVersion = '4.12'
-    materialDialogsVersion = '0.9.6.0' // Depends on the android support lib. Their version must match ours.
     osmbonuspackVersion = '6.5.2'
     osmdroidVersion = '6.0.2'
     picassoVersion = '2.5.2'
@@ -129,8 +128,6 @@ dependencies {
     annotationProcessor "com.google.dagger:dagger-android-processor:$daggerVersion"
     annotationProcessor "com.google.dagger:dagger-compiler:$daggerVersion"
     annotationProcessor "com.jakewharton:butterknife-compiler:$butterknifeVersion"
-    implementation "com.afollestad.material-dialogs:core:$materialDialogsVersion" // https://github.com/afollestad/material-dialogs
-    implementation "com.afollestad.material-dialogs:commons:$materialDialogsVersion"
     implementation "com.android.support:appcompat-v7:$supportLibVersion"
     implementation "com.android.support:cardview-v7:$supportLibVersion"
     implementation "com.android.support.constraint:constraint-layout:$constraintLayoutVersion"


### PR DESCRIPTION
- Removed unused dependency `material-dialogs`.  Usage removed in commit b99753b3d61e81350950d100dbfb3140a5fc2f37
- Updated list of used libs in README.md.