### PR TITLE
Add a map scale and a note for us-only map styles

### DIFF
--- a/app/src/main/java/fi/bitrite/android/ws/ui/MapFragment.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/MapFragment.java
@@ -19,6 +19,7 @@ import android.support.v4.app.ActivityCompat;
 import android.support.v7.widget.SearchView;
 import android.util.Log;
 import android.util.SparseArray;
+import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -39,6 +40,7 @@ import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.Marker;
+import org.osmdroid.views.overlay.ScaleBarOverlay;
 import org.osmdroid.views.overlay.mylocation.IMyLocationConsumer;
 import org.osmdroid.views.overlay.mylocation.IMyLocationProvider;
 import org.osmdroid.views.overlay.mylocation.MyLocationNewOverlay;
@@ -61,6 +63,7 @@ import fi.bitrite.android.ws.api.response.UserSearchByLocationResponse;
 import fi.bitrite.android.ws.model.SimpleUser;
 import fi.bitrite.android.ws.model.User;
 import fi.bitrite.android.ws.model.ZoomedLocation;
+import fi.bitrite.android.ws.repository.BaseSettingsRepository;
 import fi.bitrite.android.ws.repository.FavoriteRepository;
 import fi.bitrite.android.ws.repository.Resource;
 import fi.bitrite.android.ws.repository.SettingsRepository;
@@ -128,7 +131,9 @@ public class MapFragment extends BaseFragment {
 
     private boolean mHasEnabledLocationProviders;
     private final BehaviorSubject<Location> mLastDeviceLocation = BehaviorSubject.create();
+
     private MyLocationNewOverlay mDeviceLocationOverlay;
+    private int mapZoomMinLoad;
 
     public static MapFragment create() {
         MapFragment mapFragment = new MapFragment();
@@ -202,7 +207,9 @@ public class MapFragment extends BaseFragment {
             // The else case is handled in onResume.
         }
 
+        mapZoomMinLoad = getResources().getInteger(R.integer.map_zoom_min_load);
         mMap.getOverlays().add(mMarkerClusterer);
+        addScaleBarOverlay();
 
         mMap.addOnFirstLayoutListener((v, left, top, right, bottom) -> {
             // We add this only here due to issues in osmdroid's setCenter/setZoom when the first
@@ -334,6 +341,7 @@ public class MapFragment extends BaseFragment {
                     POSITION_PRIORITY_FORCED);
         }
     }
+
     private void setGotoCurrentLocationStatus() {
         mBtnGotoCurrentLocation.setEnabled(mLastDeviceLocation.getValue() != null
                                            || mHasEnabledLocationProviders);
@@ -352,6 +360,27 @@ public class MapFragment extends BaseFragment {
         }
         mBtnGotoCurrentLocation.setImageDrawable(icon);
         mBtnGotoCurrentLocation.setBackgroundTintList(ColorStateList.valueOf(fillColor));
+    }
+
+    private void addScaleBarOverlay() {
+        ScaleBarOverlay mScaleBarOverlay = new ScaleBarOverlay(mMap);
+
+        // Place at bottom left with same margins as FAB
+        int offset = (int) (TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 16,
+                getResources().getDisplayMetrics()));
+        mScaleBarOverlay.setAlignBottom(true);
+        mScaleBarOverlay.setScaleBarOffset(offset, offset);
+        mScaleBarOverlay.setMinZoom(mapZoomMinLoad);
+
+        // Use distance unit set in prefs
+        mDistanceUnit = mSettingsRepository.getDistanceUnit();
+        ScaleBarOverlay.UnitsOfMeasure unit = (
+                mDistanceUnit == BaseSettingsRepository.DistanceUnit.MILES)
+                ? ScaleBarOverlay.UnitsOfMeasure.imperial
+                : ScaleBarOverlay.UnitsOfMeasure.metric;
+        mScaleBarOverlay.setUnitsOfMeasure(unit);
+
+        mMap.getOverlays().add(mScaleBarOverlay);
     }
 
     /**
@@ -437,7 +466,7 @@ public class MapFragment extends BaseFragment {
         getResumePauseDisposable().add(mDelayedUserFetchDisposable);
     }
     private void fetchUsersForCurrentMapPosition() {
-        if (mLastPosition.zoom < getResources().getInteger(R.integer.map_zoom_min_load)) {
+        if (mLastPosition.zoom < mapZoomMinLoad) {
             sendMessage(R.string.users_dont_load);
         } else {
             sendMessage(R.string.loading_users);

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -100,8 +100,8 @@
     <string name="distance_unit_kilometers_short">km</string>
     <string name="distance_unit_miles_short">mi</string>
 
-    <string name="prefs_tile_source_title">Kartentyp</string>
-    <string name="prefs_tile_source_summary">%1$s</string>
+    <string name="prefs_tile_source_title">Kartenstil</string>
+    <string name="prefs_tile_source_us_only">%1$s (nur USA)</string>
 
     <string name="prefs_message_refresh_interval_min_title">Aktualisierungsintervall für Nachrichten</string>
     <plurals name="prefs_message_refresh_interval_min_summary">

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -94,6 +94,8 @@
 
     <string name="prefs_distance_unit_title">Unidad de distancia</string>
     <string name="prefs_distance_unit_summary">Denunciar distancias en %1$s</string>
+    <string name="prefs_tile_source_title">Estilo de mapa</string>
+    <string name="prefs_tile_source_us_only">%1$s (sólo EE.UU.)</string>
     <string name="distance_unit_kilometers_long">Kilómetros</string>
     <string name="distance_unit_miles_long">Millas</string>
     <string name="distance_unit_kilometers_short">km</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -99,6 +99,9 @@
     <string name="distance_unit_kilometers_short">km</string>
     <string name="distance_unit_miles_short">mi</string>
 
+    <string name="prefs_tile_source_title">Style de la carte</string>
+    <string name="prefs_tile_source_us_only">%1$s (É.-U. seulement)</string>
+
     <!-- Non-english speakers might prefer the default location to be over Africa, Europe & Central Asia. -->
     <!-- Sorry to all Brits (who default to the US) and rest of the non-western world. -->
     <string name="prefs_map_location_latitude_default">40.0000</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,8 +105,9 @@
     <string name="distance_unit_miles_short_raw" translatable="false">mi</string>
 
     <string name="prefs_tile_source_key" translatable="false">tile_source</string>
-    <string name="prefs_tile_source_title">Map type</string>
+    <string name="prefs_tile_source_title">Map style</string>
     <string name="prefs_tile_source_summary">%1$s</string>
+    <string name="prefs_tile_source_us_only">%1$s (US only)</string>
 
     <string name="prefs_message_refresh_interval_min_key" translatable="false">message_reload_interval_min</string>
     <string name="prefs_message_refresh_interval_min_title">Messages poll frequency</string>


### PR DESCRIPTION
**Map view**
- add a scale in the bottom-left corner
- scale is shown starting at the zoom level at which users are loaded

**Preferences menu**
- rephrased "Map type" to "Map style"
- added translations for Spanish and French. Neither is my mother tongue, but it should be comprehensible.

**Map style menu**
- USGS maps are only available in the US. A note, "US only", is appended to their menu entries
- use alphabetical order for menu entries with the exception of the USGS maps. They are added at the bottom of the list.
