### PR TITLE
Always close navigation drawer if item tapped

### DIFF
--- a/app/src/main/java/fi/bitrite/android/ws/ui/MainActivity.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/MainActivity.java
@@ -316,13 +316,13 @@ public class MainActivity extends AppCompatActivity implements HasSupportFragmen
     private void onNavigationItemClicked(NavigationItem navigationItem) {
         final String itemTag = navigationItem.tag;
 
+        // Closes the drawer.
+        mMainLayout.closeDrawers();
+
         // No action if this is the current fragment.
         if (itemTag.equals(mNavigationController.getTopLevelNavigationItemTag().getValue())) {
             return;
         }
-
-        // Closes the drawer.
-        mMainLayout.closeDrawers();
 
         // Shows the fragment.
         mNavigationController.navigateToTag(itemTag);


### PR DESCRIPTION
Before, if a user tapped on an item in the navigation bar that was already opened, nothing did happen. This PR changes this behaviour and the navigation drawer does close in cases like this, too.