### PR TITLE
[WIP] Set targetSdkVersion to 27 and use Runtime Permissions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -94,7 +94,7 @@ android {
 
         minSdkVersion 16
         compileSdkVersion 27 // also update in .travis.yml
-        targetSdkVersion 22
+        targetSdkVersion 27
 
         vectorDrawables.useSupportLibrary = true
     }
@@ -121,7 +121,7 @@ ext {
     robolectricVersion = '3.7'
     rxAndroidVersion = '2.0.2'
     rxJavaVersion = '2.1.7'
-    supportLibVersion = '27.0.1'
+    supportLibVersion = '27.1.1'
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,18 +3,25 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     package="fi.bitrite.android.ws">
 
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_LOCATION_EXTRA_COMMANDS" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
-    <uses-permission android:name="android.permission.GET_ACCOUNTS" />
+    <!-- general usage -->
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+    <!-- osmdroid -->
+    <!-- ACCESS_FINE_LOCATION includes ACCESS_COARSE_LOCATION -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
+    <!-- for offline maps and to cache on sdcard -->
+    <!-- WRITE_EXTERNAL_STORAGE includes READ_EXTERNAL_STORAGE -->
+    <!-- <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" /> -->
+
+    <!-- Account Manager -->
+    <uses-permission android:name="android.permission.GET_ACCOUNTS" />
+    <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" android:maxSdkVersion="22" />
+    <uses-permission android:name="android.permission.USE_CREDENTIALS" android:maxSdkVersion="22" />
+    <uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" android:maxSdkVersion="22" />
+
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-    <uses-permission android:name="android.permission.USE_CREDENTIALS" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <uses-feature
         android:name="android.hardware.location.gps"
@@ -37,7 +44,7 @@
         <service
             android:name=".auth.AuthenticationService"
             android:exported="true"
-            android:permission="android.permission.GET_ACCOUNTS">
+            android:permission="android.permission.GET_ACCOUNTS" >
             <intent-filter>
                 <action android:name="android.accounts.AccountAuthenticator" />
             </intent-filter>

--- a/app/src/main/java/fi/bitrite/android/ws/persistence/MessageDao.java
+++ b/app/src/main/java/fi/bitrite/android/ws/persistence/MessageDao.java
@@ -125,6 +125,7 @@ public class MessageDao extends Dao {
             deleteParticipantsExcept(db, thread.id, thread.participantIds);
 
             List<Integer> messageIds = new ArrayList<>(thread.messages.size());
+            // FIXME: got java.util.ConcurrentModificationException, coming from MessageRepository.java:278
             for (Message message : thread.messages) {
                 messageIds.add(message.id);
                 saveMessage(db, message);

--- a/app/src/main/java/fi/bitrite/android/ws/repository/BaseSettingsRepository.java
+++ b/app/src/main/java/fi/bitrite/android/ws/repository/BaseSettingsRepository.java
@@ -23,6 +23,7 @@ public abstract class BaseSettingsRepository {
     private final static String KEYSUFFIX_LOCATION_LATITUDE = "_latitude";
     private final static String KEYSUFFIX_LOCATION_LONGITUDE = "_longitude";
     private final static String KEYSUFFIX_LOCATION_ZOOM = "_zoom";
+    private final static String HIDE_CURRENT_LOCATION_BTN = "hide_current_location_button";
 
     private final String mKeyDistanceUnit;
     private final String mKeyTileSource;
@@ -44,6 +45,7 @@ public abstract class BaseSettingsRepository {
     private final String mDistanceUnitMilesShort;
     private final String mDistanceUnitKilometerLong;
     private final String mDistanceUnitMilesLong;
+
 
     BaseSettingsRepository(Context context) {
         mSharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
@@ -149,6 +151,13 @@ public abstract class BaseSettingsRepository {
                 mKeyDevSimulateNoNetwork, mDefaultDevSimulateNoNetwork);
     }
 
+    public void setHideLocationButton(boolean hideLocationButton) {
+        mSharedPreferences.edit().putBoolean(HIDE_CURRENT_LOCATION_BTN, hideLocationButton).apply();
+    }
+
+    public boolean getHideLocationButton() {
+        return mSharedPreferences.getBoolean(HIDE_CURRENT_LOCATION_BTN, false);
+    }
 
     public void registerOnChangeListener(
             SharedPreferences.OnSharedPreferenceChangeListener listener) {

--- a/app/src/main/java/fi/bitrite/android/ws/ui/MainActivity.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/MainActivity.java
@@ -205,6 +205,12 @@ public class MainActivity extends AppCompatActivity implements HasSupportFragmen
         mResumePauseDisposables.add(mAccountManager.getCurrentAccount()
                 .subscribe(nullableAccount -> {
                     Account previousAccount = mAccountHelper.mAccount;
+
+                    if (previousAccount != null && previousAccount.equals(nullableAccount.data)) {
+                        // Account did not change, do nothing.
+                        return;
+                    }
+
                     mAccountHelper.switchAccount(nullableAccount.data);
 
                     if (nullableAccount.isNull() ||

--- a/app/src/main/java/fi/bitrite/android/ws/ui/MainActivity.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/MainActivity.java
@@ -242,6 +242,7 @@ public class MainActivity extends AppCompatActivity implements HasSupportFragmen
         setIntent(intent);
         handleActionIntents(intent);
     }
+
     private void handleActionIntents(Intent intent) {
         if (mAccountHelper.hasAccount()) {
             // We need an account to be able to show any fragments.

--- a/app/src/main/java/fi/bitrite/android/ws/ui/MapFragment.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/MapFragment.java
@@ -15,7 +15,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.design.widget.FloatingActionButton;
-import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.SearchView;
 import android.util.Log;
 import android.util.SparseArray;
@@ -85,6 +85,7 @@ import io.reactivex.subjects.BehaviorSubject;
 public class MapFragment extends BaseFragment {
     public static final String KEY_MAP_TARGET_LAT_LNG = "map_target_lat_lng";
     private static final String TAG = "MapFragment";
+    private static final int REQUEST_CODE_FINE_LOCATION = 124;
 
     @Inject LoggedInUserHelper mLoggedInUserHelper;
     @Inject UserRegionalCache mUserRegionalCache;
@@ -93,7 +94,6 @@ public class MapFragment extends BaseFragment {
 
     @BindColor(R.color.primaryColor) int mColorPrimary;
     @BindColor(R.color.primaryWhite) int mColorPrimaryWhite;
-    @BindColor(R.color.primaryButtonDisable) int mColorPrimaryButtonDisable;
     @BindDrawable(R.drawable.ic_my_location_white_24dp) Drawable mIcMyLocationWhite;
     @BindDrawable(R.drawable.ic_my_location_grey600_24dp) Drawable mIcMyLocationGrey;
     @BindView(R.id.map) MapView mMap;
@@ -103,10 +103,9 @@ public class MapFragment extends BaseFragment {
 
     private Unbinder mUnbinder;
 
-    private SparseArray<Marker> mClusteredUsers = new SparseArray<>();
+    private final SparseArray<Marker> mClusteredUsers = new SparseArray<>();
     private UserMarkerClusterer mMarkerClusterer;
 
-    private Disposable mLoadOfflineUserDisposable;
     private final List<Integer> mOfflineUserIds = new ArrayList<>();
 
     private Toast mLastToast = null;
@@ -126,10 +125,11 @@ public class MapFragment extends BaseFragment {
     private static final int POSITION_PRIORITY_LAST_STORED = 2;
     private static final int POSITION_PRIORITY_FORCED = 100;
 
+    private boolean hideLocationBtn;
     private int mLastPositionType;
     private ZoomedLocation mLastPosition;
     private boolean mOsmdroidBug_suppressCallbacks;
-    private final LocationManager mLocationManager = new LocationManager();
+    private LocationManager mLocationManager;
 
     private boolean mHasEnabledLocationProviders;
     private final BehaviorSubject<Location> mLastDeviceLocation = BehaviorSubject.create();
@@ -161,6 +161,10 @@ public class MapFragment extends BaseFragment {
         mMarkerClusterer.setSingleLocationMarkerFactory(singleLocationMarkerFactory);
         mMarkerClusterer.setMultiLocationMarkerFactory(multiLocationMarkerFactory);
         mMarkerClusterer.setOnClusterClickListener(this::onClusterClick);
+
+        hideLocationBtn = mSettingsRepository.getHideLocationButton();
+
+        loadOfflineUsers();
     }
 
     @Nullable
@@ -170,11 +174,12 @@ public class MapFragment extends BaseFragment {
         Context context = getContext();
         Configuration.getInstance().load(
                 context, PreferenceManager.getDefaultSharedPreferences(context));
-        //setting this before the layout is inflated is a good idea
-        //it 'should' ensure that the map has a writable location for the map cache, even without permissions
-        //if no tiles are displayed, you can try overriding the cache path using Configuration.getInstance().setCachePath
-        //see also StorageUtils
-        //note, the load method also sets the HTTP User Agent to your application's package name, abusing osm's tile servers will get you banned based on this string
+        // setting this before the layout is inflated is a good idea
+        // it 'should' ensure that the map has a writable location for the map cache, even without
+        // permissions. if no tiles are displayed, you can try overriding the cache path using
+        // Configuration.getInstance().setCachePath. see also StorageUtils. note, the load method
+        // also sets the HTTP User Agent to your application's package name, abusing osm's
+        // tile servers will get you banned based on this string
 
         View view = inflater.inflate(R.layout.fragment_map, container, false);
         mUnbinder = ButterKnife.bind(this, view);
@@ -196,8 +201,7 @@ public class MapFragment extends BaseFragment {
         mMap.setTileSource(TileSourceFactory.getTileSource(tileSourceStr));
 
         if (hasPermission(Manifest.permission.ACCESS_FINE_LOCATION)) {
-            handleAccessFineLocationGranted();
-            // The else case is handled in onResume.
+            addMyLocationOverlay();
         }
 
         mMap.getOverlays().add(mMarkerClusterer);
@@ -237,18 +241,93 @@ public class MapFragment extends BaseFragment {
     @Override
     public void onResume() {
         super.onResume();
-
         mMap.onResume();
 
         // Register the settings change listener. That does an initial call to the handler.
         mSettingsRepository.registerOnChangeListener(mOnSettingsChangeListener);
 
-        // Adds a button to navigate to the current GPS position.
-        if (!hasPermission(Manifest.permission.ACCESS_FINE_LOCATION)) {
-            requestPermissions(new String[]{ Manifest.permission.ACCESS_FINE_LOCATION }, 0);
-        } else {
+        if (hasPermission(Manifest.permission.ACCESS_FINE_LOCATION)) {
+            hideLocationBtn = false;
+            if (mDeviceLocationOverlay == null) {
+                // if the user gave permission while the fragment was paused, mDeviceLocationOverlay
+                // is not initalized and the location button might be hidden
+                addMyLocationOverlay();
+            }
             startLocationManager();
+        } else {
+            setGotoCurrentLocationStatus();
         }
+        mBtnGotoCurrentLocation.setVisibility(hideLocationBtn ? View.GONE : View.VISIBLE);
+    }
+
+    @Override
+    public void onPause() {
+        if (mLocationManager != null) {
+            mLocationManager.stop();
+        }
+
+        mSettingsRepository.unregisterOnChangeListener(mOnSettingsChangeListener);
+        mMap.onPause();
+
+        super.onPause();
+    }
+
+    @Override
+    public void onStop() {
+        if (mLastPosition != null) {
+            mSettingsRepository.setLastMapLocation(mLastPosition);
+        }
+        mSettingsRepository.setHideLocationButton(hideLocationBtn);
+
+        super.onStop();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        mUnbinder.unbind();
+    }
+
+    private boolean hasPermission(String permission) {
+        return PackageManager.PERMISSION_GRANTED ==
+               ContextCompat.checkSelfPermission(requireActivity(), permission);
+    }
+
+    private void askForPermission(String permission, int requestCode) {
+        requestPermissions(new String[]{ permission }, requestCode);
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+                                           @NonNull int[] grantResults) {
+        switch (requestCode) {
+            case REQUEST_CODE_FINE_LOCATION:
+                if (grantResults.length > 0
+                    && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    addMyLocationOverlay();
+                    startLocationManager();
+                    onGotoCurrentLocationClicked();
+                } else {
+                    // if the permission for location is denied with checked "Never ask again",
+                    // the current location button will be hidden.
+                    hideLocationBtn = !shouldShowRequestPermissionRationale(permissions[0]);
+                }
+
+                setGotoCurrentLocationStatus();
+                break;
+            default:
+                super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        }
+    }
+
+    private void startLocationManager() {
+        if (mLocationManager == null) {
+            mLocationManager = new LocationManager();
+        }
+
+        mLocationManager.start(
+                (android.location.LocationManager) requireActivity().getSystemService(
+                        Context.LOCATION_SERVICE));
 
         getResumePauseDisposable().add(mLocationManager.getHasEnabledProviders()
                 .observeOn(AndroidSchedulers.mainThread())
@@ -271,43 +350,7 @@ public class MapFragment extends BaseFragment {
                 }));
     }
 
-    @Override
-    public void onPause() {
-        mLocationManager.stop();
-        mSettingsRepository.unregisterOnChangeListener(mOnSettingsChangeListener);
-        mMap.onPause();
-
-        super.onPause();
-    }
-
-    @Override
-    public void onStop() {
-        if (mLastPosition != null) {
-            mSettingsRepository.setLastMapLocation(mLastPosition);
-        }
-
-        super.onStop();
-    }
-
-    @Override
-    public void onDestroyView() {
-        super.onDestroyView();
-        mUnbinder.unbind();
-    }
-
-    private boolean hasPermission(String permission) {
-        return PackageManager.PERMISSION_GRANTED ==
-               ActivityCompat.checkSelfPermission(getContext(), permission);
-    }
-    @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
-                                           @NonNull int[] grantResults) {
-        if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-            // ACCESS_FINE_LOCATION is granted.
-            handleAccessFineLocationGranted();
-        }
-    }
-    private void handleAccessFineLocationGranted() {
+    private void addMyLocationOverlay() {
         mDeviceLocationOverlay = new MyLocationNewOverlay(mLocationProvider, mMap);
         mDeviceLocationOverlay.enableMyLocation();
         mDeviceLocationOverlay.setDrawAccuracyEnabled(true);
@@ -315,21 +358,18 @@ public class MapFragment extends BaseFragment {
         mDeviceLocationOverlay.disableFollowLocation(); // Initially do not follow the current location.
         mDeviceLocationOverlay.setOptionsMenuEnabled(true);
         mMap.getOverlays().add(mDeviceLocationOverlay);
-
-        startLocationManager();
-    }
-
-    private void startLocationManager() {
-        mLocationManager.start((android.location.LocationManager) getActivity().getSystemService(
-                Context.LOCATION_SERVICE));
     }
 
     @OnClick(R.id.map_btn_goto_current_location)
     void onGotoCurrentLocationClicked() {
+        if (!hasPermission(Manifest.permission.ACCESS_FINE_LOCATION)) {
+            askForPermission(Manifest.permission.ACCESS_FINE_LOCATION, REQUEST_CODE_FINE_LOCATION);
+            return;
+        }
+
         mDeviceLocationOverlay.enableFollowLocation(); // Follow the current location.
         if (mLastDeviceLocation.getValue() == null) {
-            Toast.makeText(getContext(), R.string.unknown_location, Toast.LENGTH_SHORT)
-                    .show();
+            Toast.makeText(getContext(), R.string.unknown_location, Toast.LENGTH_SHORT).show();
         } else {
             double zoom = Math.max(13, Math.min(17, mMap.getZoomLevelDouble())); // zoom \in [13,17]
             moveMapToLocation(Tools.locationToLatLng(mLastDeviceLocation.getValue()), zoom,
@@ -338,9 +378,6 @@ public class MapFragment extends BaseFragment {
     }
 
     private void setGotoCurrentLocationStatus() {
-        mBtnGotoCurrentLocation.setEnabled(mLastDeviceLocation.getValue() != null
-                                           || mHasEnabledLocationProviders);
-
         int fillColor;
         Drawable icon;
         if (mLastDeviceLocation.getValue() != null) {
@@ -350,8 +387,9 @@ public class MapFragment extends BaseFragment {
             icon = mIcMyLocationGrey;
             fillColor = mColorPrimaryWhite;
         } else {
-            icon = mIcMyLocationWhite;
-            fillColor = mColorPrimaryButtonDisable;
+            icon = mIcMyLocationGrey;
+            fillColor = mColorPrimaryWhite;
+            mBtnGotoCurrentLocation.setAlpha(0.7f);
         }
         mBtnGotoCurrentLocation.setImageDrawable(icon);
         mBtnGotoCurrentLocation.setBackgroundTintList(ColorStateList.valueOf(fillColor));
@@ -419,7 +457,8 @@ public class MapFragment extends BaseFragment {
             return;
         }
 
-        if (mLastDeviceLocation.getValue() != null) {
+        if (hasPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+            && mLastDeviceLocation.getValue() != null) {
             moveMapToLocation(Tools.locationToLatLng(mLastDeviceLocation.getValue()), showUserZoom,
                     POSITION_PRIORITY_LAST_DEVICE_POSITION);
             return;
@@ -444,7 +483,7 @@ public class MapFragment extends BaseFragment {
         mLastPosition = new ZoomedLocation(mapCenter.getLatitude(), mapCenter.getLongitude(), zoom);
 
         // If not connected, we'll switch to offline/starred users mode
-        if (!Tools.isNetworkConnected(getContext())) {
+        if (!Tools.isNetworkConnected(requireContext())) {
             sendMessage(R.string.map_network_not_connected);
             return;
         }
@@ -460,6 +499,7 @@ public class MapFragment extends BaseFragment {
                 .subscribe(this::fetchUsersForCurrentMapPosition);
         getResumePauseDisposable().add(mDelayedUserFetchDisposable);
     }
+
     private void fetchUsersForCurrentMapPosition() {
         if (mLastPosition.zoom < mMapZoomMinLoad) {
             sendMessage(R.string.users_dont_load);
@@ -538,7 +578,7 @@ public class MapFragment extends BaseFragment {
      * - If the bounds are empty (all users at same place) then let it pop the info window
      * - Otherwise, move the camera to show the bounds of the map
      */
-    public boolean onClusterClick(MapView mapView, StaticCluster cluster) {
+    private boolean onClusterClick(MapView mapView, StaticCluster cluster) {
         // Find out the bounds of the users currently in cluster
         List<SimpleUser> users = new ArrayList<>(cluster.getSize());
         List<IGeoPoint> locations = new ArrayList<>(cluster.getSize());
@@ -587,11 +627,11 @@ public class MapFragment extends BaseFragment {
 
         // Get the SearchView and set the searchable configuration
         SearchManager searchManager =
-                (SearchManager) getActivity().getSystemService(Context.SEARCH_SERVICE);
+                (SearchManager) requireActivity().getSystemService(Context.SEARCH_SERVICE);
         SearchView searchView = (SearchView) menu.findItem(R.id.action_search).getActionView();
         // Assumes current activity is the searchable activity
         searchView.setSearchableInfo(
-                searchManager.getSearchableInfo(getActivity().getComponentName()));
+                searchManager.getSearchableInfo(requireActivity().getComponentName()));
         searchView.setIconifiedByDefault(false); // Do not iconify the widget; expand it by default
     }
 
@@ -643,7 +683,7 @@ public class MapFragment extends BaseFragment {
         }
     }
 
-    private IMyLocationProvider mLocationProvider = new IMyLocationProvider() {
+    private final IMyLocationProvider mLocationProvider = new IMyLocationProvider() {
         private Disposable mDisposable;
 
         @Override

--- a/app/src/main/java/fi/bitrite/android/ws/ui/MapFragment.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/MapFragment.java
@@ -106,8 +106,6 @@ public class MapFragment extends BaseFragment {
     private final SparseArray<Marker> mClusteredUsers = new SparseArray<>();
     private UserMarkerClusterer mMarkerClusterer;
 
-    private final List<Integer> mOfflineUserIds = new ArrayList<>();
-
     private Toast mLastToast = null;
 
     private SettingsRepository.DistanceUnit mDistanceUnit;
@@ -530,9 +528,7 @@ public class MapFragment extends BaseFragment {
         Disposable loadOfflineUserDisposable = Observable.merge(mFavoriteRepository.getFavorites())
                 .filter(Resource::hasData)
                 .map(userResource -> userResource.data)
-                // Users pop up twice as one is the error since we might not be able to load it
-                // from the network.
-                .filter(user -> mOfflineUserIds.add(user.id))
+                .distinct()
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(user -> {
                     addUserToCluster(user);

--- a/app/src/main/java/fi/bitrite/android/ws/ui/MapFragment.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/MapFragment.java
@@ -38,7 +38,6 @@ import org.osmdroid.events.ScrollEvent;
 import org.osmdroid.events.ZoomEvent;
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
 import org.osmdroid.util.BoundingBox;
-import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.Marker;
 import org.osmdroid.views.overlay.ScaleBarOverlay;
@@ -84,7 +83,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.subjects.BehaviorSubject;
 
 public class MapFragment extends BaseFragment {
-    private static final String KEY_MAP_TARGET_LAT_LNG = "map_target_lat_lng";
+    public static final String KEY_MAP_TARGET_LAT_LNG = "map_target_lat_lng";
     private static final String TAG = "MapFragment";
 
     @Inject LoggedInUserHelper mLoggedInUserHelper;
@@ -139,16 +138,7 @@ public class MapFragment extends BaseFragment {
     @BindInt(R.integer.map_zoom_min_load) int mMapZoomMinLoad;
 
     public static MapFragment create() {
-        MapFragment mapFragment = new MapFragment();
-        Bundle bundle = new Bundle();
-        mapFragment.setArguments(bundle);
-        return mapFragment;
-    }
-    public static MapFragment create(IGeoPoint latLng) {
-        MapFragment mapFragment = create();
-        mapFragment.getArguments().putParcelable(KEY_MAP_TARGET_LAT_LNG,
-                new GeoPoint(latLng.getLatitude(), latLng.getLongitude()));
-        return mapFragment;
+        return new MapFragment();
     }
 
     @Override
@@ -415,8 +405,8 @@ public class MapFragment extends BaseFragment {
         float showUserZoom = getResources().getInteger(R.integer.map_showuser_zoom);
 
         // If we were launched with an intent asking us to zoom to a member
-        IGeoPoint targetLatLng = getArguments().getParcelable(KEY_MAP_TARGET_LAT_LNG);
-        if (targetLatLng != null) {
+        if (getArguments() != null && getArguments().containsKey(KEY_MAP_TARGET_LAT_LNG)) {
+            IGeoPoint targetLatLng = getArguments().getParcelable(KEY_MAP_TARGET_LAT_LNG);
             moveMapToLocation(targetLatLng, showUserZoom, POSITION_PRIORITY_FORCED);
             return;
         }
@@ -497,7 +487,7 @@ public class MapFragment extends BaseFragment {
 
     private void loadOfflineUsers() {
         // We'll show the starred users until we load a fresh version of them.
-        mLoadOfflineUserDisposable = Observable.merge(mFavoriteRepository.getFavorites())
+        Disposable loadOfflineUserDisposable = Observable.merge(mFavoriteRepository.getFavorites())
                 .filter(Resource::hasData)
                 .map(userResource -> userResource.data)
                 // Users pop up twice as one is the error since we might not be able to load it
@@ -508,7 +498,7 @@ public class MapFragment extends BaseFragment {
                     addUserToCluster(user);
                     mMarkerClusterer.invalidate();
                 });
-        getCreateDestroyDisposable().add(mLoadOfflineUserDisposable);
+        getCreateDestroyDisposable().add(loadOfflineUserDisposable);
     }
 
     private void loadCachedUsers() {


### PR DESCRIPTION
### Version updates

- targetSdkVersion to 27 (see #300). This might break the message reloading!
- support libs to 27.1.1 (to use `requireActivity` and `requireContext`)

### Add Runtime Permissions
Runtime permissions are used in API >= 23, [more details here](https://developer.android.com/guide/topics/permissions/overview). Earlier API versions enable all permissions on installation. Currently, the only permission we have to ask for during runtime is for Location (GPS/Network).

Implemented behaviour (API >= 23 only): 
- ask for permission to use Location when user clicks the Location button the first time
- if the user denies twice and checks the "Never ask again" checkbox, the location button is hidden
- the user can (re-)enable the permission through the app settings, the button will be visible again

### Other changes
- rechecked permissions and removed deprecated/unneeded and added maxSdkVersions
- reuse some of the fragments if they are already in the backstack
- prevent an unneccessary recreating of the MainFragment
- replace code with equivalent RxJava chain operations
- fix location button transparency (used when no location and no location provider are found)
- assume (0, 0) GPS coordinates are erroneous


_[Update: message reloading while the app is in the background still works on Oreo (tested with Genymotion), but no notification is shown]_
