### PR TITLE
Enable TLS 1.2 on Android 4.x. Fixes #299.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,7 +92,7 @@ android {
         versionName "${versionMajor}.${versionMinor}.${versionPatch}"
         versionCode versionMajor * 10000 + versionMinor * 1000 + versionPatch * 100 + versionBuild
 
-        minSdkVersion 14
+        minSdkVersion 16
         compileSdkVersion 27 // also update in .travis.yml
         targetSdkVersion 22
 

--- a/app/src/main/java/fi/bitrite/android/ws/api/OkHttpClientProvider.java
+++ b/app/src/main/java/fi/bitrite/android/ws/api/OkHttpClientProvider.java
@@ -1,0 +1,126 @@
+package fi.bitrite.android.ws.api;
+
+
+import android.os.Build;
+import android.util.Log;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Collections;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
+import okhttp3.ConnectionSpec;
+import okhttp3.OkHttpClient;
+import okhttp3.TlsVersion;
+
+/**
+ *
+ * This class is needed for TLS 1.2 support on Android 4.x
+ *
+ * See http://blog.dev-area.net/2015/08/13/android-4-1-enable-tls-1-1-and-tls-1-2/ and
+ * https://github.com/square/okhttp/issues/2372
+ */
+class OkHttpClientProvider {
+
+    static OkHttpClient.Builder createClientBuilder() {
+        OkHttpClient.Builder client = new OkHttpClient.Builder();
+        return enableTls12OnPreLollipop(client);
+    }
+
+    private static OkHttpClient.Builder enableTls12OnPreLollipop(OkHttpClient.Builder client) {
+        if (Build.VERSION.SDK_INT >= 21) {
+            return client;
+        }
+
+        try {
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
+                    TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init((KeyStore) null);
+            TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
+            if (trustManagers.length != 1 || !(trustManagers[0] instanceof X509TrustManager)) {
+                throw new IllegalStateException("Unexpected default trust managers:"
+                                                + Arrays.toString(trustManagers));
+            }
+            X509TrustManager trustManager = (X509TrustManager) trustManagers[0];
+
+            client.sslSocketFactory(new TLSSocketFactory(), trustManager);
+
+            ConnectionSpec cs = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+                    .tlsVersions(TlsVersion.TLS_1_2).build();
+
+            client.connectionSpecs(Collections.singletonList(cs));
+        } catch (Exception exc) {
+            Log.e("OkHttpClientProvider", "Error while enabling TLS 1.2", exc);
+        }
+
+        return client;
+    }
+
+    private static class TLSSocketFactory extends SSLSocketFactory {
+        private SSLSocketFactory delegate;
+
+        TLSSocketFactory() throws KeyManagementException, NoSuchAlgorithmException {
+            SSLContext context = SSLContext.getInstance("TLS");
+            context.init(null, null, null);
+            delegate = context.getSocketFactory();
+        }
+
+        @Override
+        public String[] getDefaultCipherSuites() {
+            return delegate.getDefaultCipherSuites();
+        }
+
+        @Override
+        public String[] getSupportedCipherSuites() {
+            return delegate.getSupportedCipherSuites();
+        }
+
+        @Override
+        public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws
+                                                                                       IOException {
+            return enableTLSOnSocket(delegate.createSocket(s, host, port, autoClose));
+        }
+
+        @Override
+        public Socket createSocket(String host, int port) throws IOException {
+            return enableTLSOnSocket(delegate.createSocket(host, port));
+        }
+
+        @Override
+        public Socket createSocket(String host, int port, InetAddress localHost, int localPort)
+                throws IOException {
+            return enableTLSOnSocket(delegate.createSocket(host, port, localHost, localPort));
+        }
+
+        @Override
+        public Socket createSocket(InetAddress host, int port) throws IOException {
+            return enableTLSOnSocket(delegate.createSocket(host, port));
+        }
+
+        @Override
+        public Socket createSocket(InetAddress address, int port, InetAddress localAddress,
+                                   int localPort) throws IOException {
+            return enableTLSOnSocket(delegate.createSocket(address, port, localAddress, localPort));
+        }
+
+        private Socket enableTLSOnSocket(Socket socket) {
+            if (socket instanceof SSLSocket) {
+                ((SSLSocket) socket).setEnabledProtocols(
+                        new String[]{ "TLSv1", "TLSv1.1", "TLSv1.2" });
+            }
+            return socket;
+        }
+    }
+
+}

--- a/app/src/main/java/fi/bitrite/android/ws/api/ServiceFactory.java
+++ b/app/src/main/java/fi/bitrite/android/ws/api/ServiceFactory.java
@@ -54,8 +54,7 @@ public class ServiceFactory {
 
     private static OkHttpClient.Builder createDefaultClientBuilder(
             DefaultInterceptor defaultInterceptor) {
-        return  new OkHttpClient.Builder()
-                .addInterceptor(defaultInterceptor);
+       return OkHttpClientProvider.createClientBuilder().addInterceptor(defaultInterceptor);
     }
     private static GsonBuilder createDefaultGsonBuilder() {
         final BooleanDeserializer booleanDeserializer = new BooleanDeserializer();


### PR DESCRIPTION
- update minSdkVersion from 14 to 16
- enables TLS 1.2 on 4.x
- based on code listed in https://github.com/square/okhttp/issues/2372 and used for https://github.com/facebook/react-native/pull/9840/commits/fc7d451fdfcd0659b5cd279fb13161d20d12721d

Fixes errors on 4.1.1 and 4.4.4 as described in https://github.com/warmshowers/wsandroid/issues/299#issue-358301886, tested with Genymotion.
