### PR TITLE
Fix NPE in MapFragment

### DIFF
--- a/app/src/main/java/fi/bitrite/android/ws/ui/MapFragment.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/MapFragment.java
@@ -173,8 +173,6 @@ public class MapFragment extends BaseFragment {
         mMarkerClusterer.setOnClusterClickListener(this::onClusterClick);
 
         mHideLocationBtn = mSettingsRepository.getHideLocationButton();
-
-        loadOfflineUsers();
     }
 
     @Nullable
@@ -247,7 +245,6 @@ public class MapFragment extends BaseFragment {
             doInitialMapMove();
         });
 
-        loadOfflineUsers();
         loadCachedUsers();
 
         return view;
@@ -257,6 +254,9 @@ public class MapFragment extends BaseFragment {
     public void onResume() {
         super.onResume();
         mMap.onResume();
+
+        // Load favorite users and react to changes.
+        loadOfflineUsers();
 
         // Register the settings change listener. That does an initial call to the handler.
         mSettingsRepository.registerOnChangeListener(mOnSettingsChangeListener);
@@ -563,7 +563,7 @@ public class MapFragment extends BaseFragment {
                     addUserToCluster(user, mFavoriteRepository.isFavorite(user.id));
                     mMarkerClusterer.invalidate();
                 });
-        getCreateDestroyDisposable().add(loadOfflineUserDisposable);
+        getResumePauseDisposable().add(loadOfflineUserDisposable);
     }
 
     private void loadCachedUsers() {
@@ -583,7 +583,7 @@ public class MapFragment extends BaseFragment {
             mMarkerClusterer.remove(existingMarker);
         }
 
-        UserMarker marker = new UserMarker(getContext(), mMap, user);
+        UserMarker marker = new UserMarker(requireContext(), mMap, user);
         marker.setAnchor(UserMarker.ANCHOR_CENTER, UserMarker.ANCHOR_BOTTOM);
         marker.setIcon(getMarkerIconForHost(isFavoriteHost));
         marker.setOnMarkerClickListener((m, mapView) -> {


### PR DESCRIPTION
Markers for favorite users were drawn even if no context was around in
the MapFragment after the fragment went out of scope but was not
destroyed, yet.

Was reproducable by

1. have some favorites
2. open e.g. the messages fragment
3. switch to the favorites fragment -> NPE in the MapFragment.