### PR TITLE
Make Travis CI succeed for PRs from forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,13 @@ before_script:
        export WS_PROD_KEYSTORE_FILE="$HOME/warmshowers.jks";
      fi'
 
+  # Sets a dummy API key for builds for PRs from forks as encrypted variables
+  # are not available there.
+  - 'if [ "${TRAVIS_SECURE_ENV_VARS}" != "true" ] && [ -z "$WS_API_KEY" ]; then
+       export WS_API_KEY="dummy_api_key";
+       export WS_API_USER_ID="dummy_api_user_id";
+     fi'
+
   # Sets the NDK path.
   - export ANDROID_NDK_HOME="$ANDROID_HOME/ndk-bundle"
 


### PR DESCRIPTION
Encrypted variables are not available for such builds and therefore
`WS_API_KEY` was not set. However, gradle throws an exception in case
that environment variable is not set. Using a dummy variable, now.

Fixes: #337