### PR TITLE
Gracefully dismiss dialog on orientation change

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -70,7 +70,6 @@
         <activity
             android:name=".ui.AuthenticatorActivity"
             android:label="@string/app_name"
-            android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".ui.MainActivity"


### PR DESCRIPTION
Dismiss dialog with user info on orientation change, avoiding a NPE. I have no information about other places where an NPE can occur on orientation change, so this should fix #342. 

Also allow login activity in landscape.