### PR TITLE
Feature/296 offline maps

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -102,6 +102,8 @@ android {
 
         buildConfigField 'String', 'WS_API_USER_ID', "\"$wsApiUserId\""
         buildConfigField 'String', 'WS_API_KEY', "\"$wsApiKey\""
+        multiDexEnabled true
+
     }
     flavorDimensions "mode"
     productFlavors {
@@ -164,23 +166,26 @@ ext {
     androidxVersion = '1.1.0'
     androidxCardViewVersion = '1.0.0'
     androidxConstraintLayoutVersion = '1.1.3'
-    androidxTestVersion = '1.0.0'
-    assertjVersion = '3.13.2'
-    autoServiceVersion = '1.0-rc4'
+    androidxTestVersion = '1.2.0'
+    assertjVersion = '3.14.0'
+    autoServiceVersion = '1.0-rc6'
     bubbleSeekbarVersion = '3.20'
     butterknifeVersion = '10.2.0'
-    daggerVersion = '2.24'
-    glideVersion = '4.9.0'
+    daggerVersion = '2.25.2'
+    glideVersion = '4.10.0'
     gsonVersion = '2.8.6'
     jsonVersion = '20190722'
     junitVersion = '4.12'
+    multiDexVersion = '2.0.1'
     mockitoVersion = '2.28.2'
-    okHttpVersion = '3.12.0'
+    okHttpVersion = '4.2.2'
     osmbonuspackVersion = '6.6.0'
-    osmdroidVersion = '6.1.0'
+    osmdroidMapforgeVersion = '6.1.2'
+    osmdroidVersion = '6.1.2'
     playServicesVersion = '17.0.0'
-    retrofitVersion = '2.6.1' // Dictates version of okhttp in their dependencies which clashes in tests.
-    robolectricVersion = '4.3'
+    retrofitVersion = '2.6.2'
+    // Dictates version of okhttp in their dependencies which clashes in tests.
+    robolectricVersion = '4.3.1'
     rxAndroidVersion = '2.1.1'
     rxJavaVersion = '2.2.12'
     securekeysVersion = '2.2.0' // Adjust the version in the project's build.gradle, too.
@@ -196,6 +201,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxVersion"
     implementation "androidx.cardview:cardview:$androidxCardViewVersion"
     implementation "androidx.constraintlayout:constraintlayout:$androidxConstraintLayoutVersion"
+    implementation "androidx.multidex:multidex:$multiDexVersion"
     implementation "androidx.preference:preference:$androidxVersion"
     implementation "com.github.bumptech.glide:glide:$glideVersion"
     implementation "com.github.MKergall:osmbonuspack:$osmbonuspackVersion"
@@ -213,6 +219,7 @@ dependencies {
     implementation "io.reactivex.rxjava2:rxandroid:$rxAndroidVersion"
     implementation "io.reactivex.rxjava2:rxjava:$rxJavaVersion"
     implementation "org.osmdroid:osmdroid-android:$osmdroidVersion"
+    implementation "org.osmdroid:osmdroid-mapsforge:$osmdroidMapforgeVersion"
 
     googleImplementation "com.google.android.gms:play-services-analytics:$playServicesVersion"
 

--- a/app/src/google/res/xml/preferences.xml
+++ b/app/src/google/res/xml/preferences.xml
@@ -1,37 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+
+Reflect changes from `app/src/main/res/xml/preferences.xml`.
+
+-->
 <PreferenceScreen
-    xmlns:android="http://schemas.android.com/apk/res/android">
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <ListPreference
-        android:defaultValue="@string/prefs_distance_unit_default"
-        android:entries="@array/prefs_distance_unit_entries"
-        android:entryValues="@array/prefs_distance_unit_entry_values"
-        android:key="@string/prefs_distance_unit_key"
-        android:summary="@string/prefs_distance_unit_summary"
-        android:title="@string/prefs_distance_unit_title" />
+    <PreferenceCategory
+        android:title="Map settings" >
 
-    <ListPreference
-        android:key="@string/prefs_tile_source_key"
-        android:summary="@string/prefs_tile_source_summary"
-        android:title="@string/prefs_tile_source_title" />
+        <ListPreference
+            android:key="@string/prefs_online_map_source"
+            android:title="@string/prefs_online_map_source_title"
+            android:summary="@string/prefs_tile_source_summary" />
 
-    <fi.bitrite.android.ws.ui.preference.RefreshIntervalPreference
-        android:defaultValue="@integer/prefs_message_refresh_interval_min_default"
-        android:dialogMessage="@string/prefs_message_refresh_interval_min_dialog_message"
-        android:inputType="number"
-        android:key="@string/prefs_message_refresh_interval_min_key"
-        android:title="@string/prefs_message_refresh_interval_min_title" />
+        <SwitchPreference
+            android:key="@string/prefs_offline_map_enabled"
+            android:title="Use offline maps"
+            android:checked="false" />
 
-    <SwitchPreference
-        android:defaultValue="@bool/prefs_data_saver_mode_default"
-        android:key="@string/prefs_data_saver_mode_key"
-        android:title="@string/prefs_data_saver_mode_title"
-        android:summary="@string/prefs_data_saver_mode_summary"/>
+        <ListPreference
+            android:key="@string/prefs_offline_theme_selection"
+            android:title="Offline map style"
+            android:summary="@string/prefs_tile_source_summary" />
 
-    <SwitchPreference
-        android:defaultValue="@bool/prefs_ga_collect_stats_default"
-        android:key="@string/prefs_ga_collect_stats_key"
-        android:summaryOff="@string/prefs_ga_collect_stats_summary_off"
-        android:summaryOn="@string/prefs_ga_collect_stats_summary_on"
-        android:title="@string/prefs_ga_collect_stats_title" />
+        <MultiSelectListPreference
+            android:key="@string/prefs_offline_map_selection"
+            android:title="Offline map source"
+            app:isPreferenceVisible="false" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="Messaging">
+
+        <fi.bitrite.android.ws.ui.preference.RefreshIntervalPreference
+            android:defaultValue="@integer/prefs_message_refresh_interval_min_default"
+            android:dialogMessage="@string/prefs_message_refresh_interval_min_dialog_message"
+            android:inputType="number"
+            android:key="@string/prefs_message_refresh_interval_min_key"
+            android:title="@string/prefs_message_refresh_interval_min_title" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="Other">
+
+        <ListPreference
+            android:defaultValue="@string/prefs_distance_unit_default"
+            android:entries="@array/prefs_distance_unit_entries"
+            android:entryValues="@array/prefs_distance_unit_entry_values"
+            android:key="@string/prefs_distance_unit_key"
+            android:summary="@string/prefs_distance_unit_summary"
+            android:title="@string/prefs_distance_unit_title" />
+
+        <SwitchPreference
+            android:defaultValue="@bool/prefs_data_saver_mode_default"
+            android:key="@string/prefs_data_saver_mode_key"
+            android:title="@string/prefs_data_saver_mode_title"
+            android:summary="@string/prefs_data_saver_mode_summary"/>
+
+        <SwitchPreference
+            android:defaultValue="@bool/prefs_ga_collect_stats_default"
+            android:key="@string/prefs_ga_collect_stats_key"
+            android:summaryOff="@string/prefs_ga_collect_stats_summary_off"
+            android:summaryOn="@string/prefs_ga_collect_stats_summary_on"
+            android:title="@string/prefs_ga_collect_stats_title" />
+
+    </PreferenceCategory>
+
+
 </PreferenceScreen>
+

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
 
     <!-- for offline maps and to cache on sdcard -->
     <!-- WRITE_EXTERNAL_STORAGE includes READ_EXTERNAL_STORAGE -->
-    <!-- <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" /> -->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <!-- Account Manager -->
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />

--- a/app/src/main/java/fi/bitrite/android/ws/BaseWSAndroidApplication.java
+++ b/app/src/main/java/fi/bitrite/android/ws/BaseWSAndroidApplication.java
@@ -1,6 +1,5 @@
 package fi.bitrite.android.ws;
 
-import android.app.Application;
 import android.content.SharedPreferences;
 
 import com.bumptech.glide.request.RequestOptions;
@@ -8,6 +7,7 @@ import com.u.securekeys.SecureEnvironment;
 
 import javax.inject.Inject;
 
+import androidx.multidex.MultiDexApplication;
 import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
 import dagger.android.HasAndroidInjector;
@@ -16,7 +16,7 @@ import fi.bitrite.android.ws.di.AppInjector;
 import fi.bitrite.android.ws.repository.SettingsRepository;
 import fi.bitrite.android.ws.util.WSGlide;
 
-public abstract class BaseWSAndroidApplication extends Application implements HasAndroidInjector {
+public abstract class BaseWSAndroidApplication extends MultiDexApplication implements HasAndroidInjector {
 
     public static final String TAG = "WSAndroidApplication";
     private static AppInjector mAppInjector;

--- a/app/src/main/java/fi/bitrite/android/ws/auth/Authenticator.java
+++ b/app/src/main/java/fi/bitrite/android/ws/auth/Authenticator.java
@@ -218,7 +218,7 @@ public class Authenticator extends AbstractAccountAuthenticator {
             WrongAPIKey,
             AccountTemporarilyBlocked,
             IpTemporarilyBlocked,
-            Unknown;
+            Unknown
         }
         public final ErrorCause errorCause;
 

--- a/app/src/main/java/fi/bitrite/android/ws/model/MapsForgeTheme.java
+++ b/app/src/main/java/fi/bitrite/android/ws/model/MapsForgeTheme.java
@@ -1,0 +1,46 @@
+package fi.bitrite.android.ws.model;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+public class MapsForgeTheme implements Serializable {
+    private String name;
+    private String id;
+    private Map<String, String> localizedNames;
+    private String filePath;
+
+    public MapsForgeTheme(String name, String id, String filePath) {
+        this.name = name;
+        this.id = id;
+        this.filePath = filePath;
+        localizedNames = new HashMap<>();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public String getLocalizedDisplayName(String lang) {
+        if (!localizedNames.containsKey(lang)) {
+            lang = "en";
+        }
+        if (localizedNames.get(lang) != null) {
+            return localizedNames.get(lang) + " (" + name + ")";
+        } else {
+            return name;
+        }
+    }
+
+    public void addLocalizedName(String lang, String name) {
+        localizedNames.put(lang, name);
+    }
+}

--- a/app/src/main/java/fi/bitrite/android/ws/ui/SettingsFragment.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/SettingsFragment.java
@@ -1,33 +1,53 @@
 package fi.bitrite.android.ws.ui;
 
+import android.Manifest;
+import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.content.res.Resources;
+import android.net.Uri;
 import android.os.Bundle;
-import androidx.fragment.app.DialogFragment;
-import androidx.fragment.app.Fragment;
-import androidx.preference.ListPreference;
-import androidx.preference.Preference;
-import androidx.preference.PreferenceFragmentCompat;
+import android.text.Html;
 import android.text.TextUtils;
+import android.util.Log;
+
+import com.google.gson.Gson;
 
 import org.osmdroid.tileprovider.tilesource.ITileSource;
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
 
+import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 import javax.inject.Inject;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.core.content.ContextCompat;
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.Fragment;
+import androidx.preference.ListPreference;
+import androidx.preference.MultiSelectListPreference;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.SwitchPreference;
 import butterknife.BindString;
 import butterknife.ButterKnife;
 import fi.bitrite.android.ws.BuildConfig;
 import fi.bitrite.android.ws.R;
 import fi.bitrite.android.ws.di.Injectable;
+import fi.bitrite.android.ws.model.MapsForgeTheme;
 import fi.bitrite.android.ws.repository.SettingsRepository;
 import fi.bitrite.android.ws.ui.preference.RefreshIntervalPreferenceDialogFragment;
 import fi.bitrite.android.ws.ui.util.ActionBarTitleHelper;
+import fi.bitrite.android.ws.ui.util.OfflineMapHelper;
 
 public class SettingsFragment extends PreferenceFragmentCompat implements Injectable,
         SharedPreferences.OnSharedPreferenceChangeListener {
@@ -35,9 +55,20 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Inject
     @Inject ActionBarTitleHelper mActionBarTitleHelper;
     @Inject SettingsRepository mSettingsRepository;
 
+    @BindString(R.string.prefs_online_map_source) String mOnlineMapSource;
+
+    @BindString(R.string.prefs_offline_map_enabled) String mOfflineMapSwitch;
+    @BindString(R.string.prefs_offline_map_selection) String mOfflineMapSelection;
+    @BindString(R.string.prefs_offline_map_source_files) String mOfflineMapSourceFiles;
+    @BindString(R.string.prefs_offline_theme_selection) String mOfflineThemeSelection;
+    @BindString(R.string.prefs_offline_theme_source_files) String mOfflineThemeSourceFiles;
+
+    @BindString(R.string.prefs_offline_map_prefer_installed_locales) String mOfflineMapLanguage;
+
     @BindString(R.string.prefs_distance_unit_key) String mKeyDistanceUnit;
-    @BindString(R.string.prefs_tile_source_key) String mTileMapSource;
     @BindString(R.string.prefs_message_refresh_interval_min_key) String mKeyMessageRefreshInterval;
+
+    private final static int MY_PERMISSIONS_REQUEST_READ_EXTERNAL_STORAGE = 667;
 
     public static Fragment create() {
         Bundle bundle = new Bundle();
@@ -50,7 +81,7 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Inject
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        ButterKnife.bind(this, getActivity());
+        ButterKnife.bind(this, requireActivity());
     }
 
     @Override
@@ -60,6 +91,20 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Inject
         mActionBarTitleHelper.set(getString(R.string.title_fragment_settings));
 
         mSettingsRepository.registerOnChangeListener(this);
+
+
+        findPreference(mOfflineMapSwitch).setSummaryProvider(
+                preference -> {
+                    String fileDir = OfflineMapHelper.defaultMapDataDirectory(requireContext());
+                    List<String> fnames = new ArrayList<>();
+                    for (File f : mSettingsRepository.getOfflineMapSourceFiles()) {
+                        fnames.add(f.getAbsolutePath().replace(fileDir, ""));
+                    }
+                    return TextUtils.join(", ", fnames);
+                }
+        );
+
+        setOfflinemapSettings();
         setSummary();
     }
 
@@ -67,6 +112,11 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Inject
     public void onPause() {
         mSettingsRepository.unregisterOnChangeListener(this);
         super.onPause();
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
     }
 
     @Override
@@ -81,25 +131,65 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Inject
 
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        if (key == null) {
+            return;
+        }
+
+        if (key.equals(mOfflineMapSwitch) && sharedPreferences.getBoolean(mOfflineMapSwitch, false)) {
+            // ask for storage permission
+            if (ContextCompat.checkSelfPermission(requireActivity(),
+                    Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+                // Permission is not granted
+                requestPermissions(
+                        new String[]{Manifest.permission.READ_EXTERNAL_STORAGE},
+                        MY_PERMISSIONS_REQUEST_READ_EXTERNAL_STORAGE);
+            } else {
+                searchOfflineMapData();
+            }
+        }
+        setOfflinemapSettings();
         setSummary();
     }
 
-    private void setSummary() {
-        // distance units
-        findPreference(mKeyDistanceUnit).setSummary(getString(
-                R.string.prefs_distance_unit_summary,
-                mSettingsRepository.getDistanceUnitLong()));
 
-        // map sources
-        setAvailableMapSources((ListPreference) findPreference(mTileMapSource));
+    private void searchOfflineMapData() {
+        OfflineMapHelper.searchOfflineMapData(mSettingsRepository,false, requireActivity());
+        Set<String> availableSources = mSettingsRepository.getAvailableOfflineMapSources();
+        if (availableSources.isEmpty()) {
+            // no maps found. show help and uncheck button
+            showMapDownloadDialog();
+            ((SwitchPreference) findPreference(mOfflineMapSwitch)).setChecked(false);
+        }
+    }
 
-        // message refresh interval
-        Resources res = getResources();
-        int intervalMin = mSettingsRepository.getMessageRefreshIntervalMin();
-        findPreference(mKeyMessageRefreshInterval).setSummary(intervalMin > 0
-                ? res.getQuantityString(R.plurals.prefs_message_refresh_interval_min_summary,
-                intervalMin, intervalMin)
-                : getString(R.string.prefs_message_refresh_interval_min_summary_disabled));
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        if (requestCode != MY_PERMISSIONS_REQUEST_READ_EXTERNAL_STORAGE) {
+            super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+            return;
+        }
+
+        if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+            searchOfflineMapData();
+        } else {
+            ((SwitchPreference) findPreference(mOfflineMapSwitch)).setChecked(false);
+        }
+        setOfflinemapSettings();
+    }
+
+
+    private void showMapDownloadDialog() {
+        new AlertDialog.Builder(requireContext())
+                .setTitle(R.string.no_offline_maps_found_title)
+                .setMessage(Html.fromHtml(String.format(getString(R.string.no_offline_maps_found_message), OfflineMapHelper.defaultMapDataDirectory(requireContext()))))
+                .setPositiveButton(R.string.alert_neutral_button, (dialog, id) -> dialog.dismiss())
+                .setNeutralButton(R.string.open_map_provider_overview, ((dialog, which) -> {
+                    String url = "https://github.com/mapsforge/mapsforge/blob/master/docs/Mapsforge-Maps.md";
+                    startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+                }))
+                .setCancelable(true)
+                .create()
+                .show();
     }
 
     @Override
@@ -111,16 +201,92 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Inject
 
         if (dialogFragment != null) {
             dialogFragment.setTargetFragment(this, 0);
-            dialogFragment.show(getFragmentManager(), dialogFragment.getClass().getCanonicalName());
+            dialogFragment.show(requireFragmentManager(), dialogFragment.getClass().getCanonicalName());
         } else {
             super.onDisplayPreferenceDialog(preference);
         }
     }
 
-    private void setAvailableMapSources(final ListPreference tileSourcePreference) {
+    private void setOfflinemapSettings() {
+        boolean offlineMapEnabled = ((SwitchPreference) findPreference(mOfflineMapSwitch)).isChecked();
+        if (offlineMapEnabled) {
+            listOfflineMapSources(findPreference(mOfflineMapSelection));
+            listOfflineStyleSources(findPreference(mOfflineThemeSelection));
+        }
+        findPreference(mOfflineThemeSelection).setEnabled(offlineMapEnabled);
+        findPreference(mOnlineMapSource).setEnabled(!offlineMapEnabled);
+
+    }
+
+    private void setSummary() {
+        // online map sources
+        listAvailableOnlineMapSources(findPreference(mOnlineMapSource));
+
+        // message refresh interval
+        Resources res = getResources();
+        int intervalMin = mSettingsRepository.getMessageRefreshIntervalMin();
+        findPreference(mKeyMessageRefreshInterval).setSummary(intervalMin > 0
+                ? res.getQuantityString(R.plurals.prefs_message_refresh_interval_min_summary,
+                intervalMin, intervalMin)
+                : getString(R.string.prefs_message_refresh_interval_min_summary_disabled));
+
+        // distance units
+        findPreference(mKeyDistanceUnit).setSummary(getString(
+                R.string.prefs_distance_unit_summary,
+                mSettingsRepository.getDistanceUnitLong()));
+    }
+
+    private void listOfflineMapSources(final MultiSelectListPreference pref) {
+        Set<String> maps = mSettingsRepository.getAvailableOfflineMapSources();
+
+        final List<String> sourceNames = new LinkedList<>();
+        final List<String> sourceValues = new LinkedList<>();
+        for (String map: maps) {
+            File f = new File(map);
+            if (f.exists()) {
+                sourceNames.add(f.getName());
+                sourceValues.add(f.getAbsolutePath());
+            }
+        }
+
+        pref.setEntries(sourceNames.toArray(new CharSequence[0]));
+        pref.setEntryValues(sourceValues.toArray(new CharSequence[0]));
+        if (pref.getValues().isEmpty() && pref.getEntryValues().length > 0) {
+            // use all maps as default
+            Set<String> values = new HashSet<>();
+            for (CharSequence cs : pref.getEntryValues()) {
+                values.add(cs.toString());
+            }
+            pref.setValues(values);
+        }
+    }
+
+    private void listOfflineStyleSources(final ListPreference pref) {
+        List<MapsForgeTheme> themes = mSettingsRepository.getAvailableOfflineThemeSources();
+
+        final List<String> sourceNames = new LinkedList<>();
+        final List<String> sourceValues = new LinkedList<>();
+        Gson gson = new Gson();
+        for (MapsForgeTheme theme : themes) {
+            if (new File(theme.getFilePath()).exists() || theme.getId().equals("default_theme")) {
+                sourceNames.add(theme.getLocalizedDisplayName(Locale.getDefault().getLanguage()));
+                sourceValues.add(gson.toJson(theme));
+            }
+        }
+
+        pref.setEntries(sourceNames.toArray(new CharSequence[0]));
+        pref.setEntryValues(sourceValues.toArray(new CharSequence[0]));
+        if (pref.getValue() == null) {
+            // if user has selected nothing, use default theme
+            pref.setSummary(themes.get(themes.size() - 1).getLocalizedDisplayName(Locale.getDefault().getLanguage()));
+            pref.setValue(pref.getEntryValues()[0].toString());
+        }
+    }
+
+    private void listAvailableOnlineMapSources(final ListPreference tileSourcePreference) {
         tileSourcePreference.setSummary(getString(
                 R.string.prefs_tile_source_summary,
-                mSettingsRepository.getTileSourceStr()));
+                mSettingsRepository.getOnlineMapSourceStr()));
         final List<String> tileSourceNames = new LinkedList<>();
         final List<String> tileSourceValues = new LinkedList<>();
         final List<ITileSource> tileSources = TileSourceFactory.getTileSources();
@@ -133,7 +299,7 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Inject
                 TileSourceFactory.ChartbundleWAC);
         tileSources.removeAll(blacklisted_sources);
 
-        // Some maps are only available in the US
+        // Some maps only cover the US
         List<ITileSource> usOnlySources = Arrays.asList(
                 TileSourceFactory.USGS_SAT,
                 TileSourceFactory.USGS_TOPO);
@@ -156,9 +322,9 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Inject
         }
 
         CharSequence[] tileSourceNamesCS =
-                tileSourceNames.toArray(new CharSequence[tileSourceNames.size()]);
+                tileSourceNames.toArray(new CharSequence[0]);
         CharSequence[] tileSourceValuesCS =
-                tileSourceValues.toArray(new CharSequence[tileSourceValues.size()]);
+                tileSourceValues.toArray(new CharSequence[0]);
 
         tileSourcePreference.setEntries(tileSourceNamesCS);
         tileSourcePreference.setEntryValues(tileSourceValuesCS);

--- a/app/src/main/java/fi/bitrite/android/ws/ui/util/OfflineMapHelper.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/util/OfflineMapHelper.java
@@ -1,0 +1,202 @@
+package fi.bitrite.android.ws.ui.util;
+
+import android.content.Context;
+import android.os.Environment;
+import android.util.Xml;
+
+import org.mapsforge.map.rendertheme.XmlRenderTheme;
+import org.mapsforge.map.rendertheme.XmlRenderThemeStyleLayer;
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import androidx.fragment.app.FragmentActivity;
+import fi.bitrite.android.ws.R;
+import fi.bitrite.android.ws.model.MapsForgeTheme;
+import fi.bitrite.android.ws.repository.SettingsRepository;
+import io.reactivex.disposables.Disposable;
+
+public class OfflineMapHelper {
+
+    public static final String TAG = "OfflineMapHelper";
+
+    public static String defaultMapDataDirectory(Context context) {
+        return context.getExternalFilesDir(null).toString() + "/";
+    }
+
+    public static boolean containsExistingFile(File[] files) {
+        for (File f : files) {
+            if (f.exists()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static void searchOfflineMapData(SettingsRepository settingsRepository, boolean extendedSearchScope, FragmentActivity activity) {
+        File[] startFolders;
+        if (extendedSearchScope) {
+            startFolders = new File[]{
+                    new File(defaultMapDataDirectory(activity)),
+                    Environment.getExternalStorageDirectory()};
+        } else {
+            startFolders = new File[]{
+                    new File(defaultMapDataDirectory(activity))};
+        }
+
+        Disposable progressDisposable = ProgressDialog.create(R.string.map_search_in_progress)
+                .showDelayed(activity, 100, TimeUnit.MILLISECONDS);
+
+        List<String> mapfiles = OfflineMapHelper.findMapsforgeMapFiles(startFolders);
+        settingsRepository.setAvailableOfflineMapSources(new HashSet<>(mapfiles));
+
+        List<MapsForgeTheme> themes = new ArrayList<>();
+        for (File themefile : OfflineMapHelper.findMapsforgeThemeFiles(startFolders)) {
+            themes.addAll(OfflineMapHelper.getThemeStyles(themefile));
+        }
+        settingsRepository.setAvailableOfflineThemeSources(themes);
+
+        progressDisposable.dispose();
+    }
+
+    private static List<String> findMapsforgeMapFiles(File[] rootFolders) {
+        List<String> mapFiles = new ArrayList<>();
+        for (File file : findFilesWithExtension(new ArrayList<>(), rootFolders, ".map")) {
+            if (isMapsforgeBinaryOSM(file)) {
+                mapFiles.add(file.getAbsolutePath());
+            }
+        }
+        return mapFiles;
+    }
+
+
+    private static List<File> findMapsforgeThemeFiles(File[] rootFolders) {
+        List<File> mapFiles = new ArrayList<>();
+        for (File file : findFilesWithExtension(new ArrayList<>(), rootFolders, ".xml")) {
+            if (isMapsforgeThemeXML(file)) {
+                mapFiles.add(file);
+            }
+        }
+        return mapFiles;
+    }
+
+    private static List<MapsForgeTheme> getThemeStyles(File theme) {
+        XmlPullParser parser = Xml.newPullParser();
+        try (InputStream in_s = new FileInputStream(theme)) {
+            parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, false);
+            parser.setInput(in_s, null);
+            return extractThemes(parser, theme.getAbsolutePath());
+        } catch (XmlPullParserException|IOException ignored) {}
+
+        return new ArrayList<>();
+    }
+
+    private static List<MapsForgeTheme> extractThemes(XmlPullParser parser, final String filePath)
+            throws XmlPullParserException, IOException {
+
+        List<MapsForgeTheme> themes = new ArrayList<>();
+
+        int eventType = parser.getEventType();
+        String elementName;
+        MapsForgeTheme theme = null;
+        while (eventType != XmlPullParser.END_DOCUMENT) {
+            switch (eventType) {
+                case XmlPullParser.START_TAG:
+                    elementName = parser.getName();
+                    if ("layer".equalsIgnoreCase(elementName)) {
+                        if ("true".equalsIgnoreCase(parser.getAttributeValue(null, "visible"))) {
+                            theme = new MapsForgeTheme(new File(filePath).getName(), parser.getAttributeValue(null, "id"), filePath);
+                        }
+                    } else if (theme != null && "name".equalsIgnoreCase(elementName)) {
+                        String lang = parser.getAttributeValue(null,"lang");
+                        String localizedThemeName = parser.getAttributeValue(null,"value");
+                        theme.addLocalizedName(lang, localizedThemeName);
+                    }
+                    break;
+                case XmlPullParser.END_TAG:
+                    elementName = parser.getName();
+                    if ("layer".equalsIgnoreCase(elementName) && theme != null ) {
+                        themes.add(theme);
+                        theme = null;
+                    }
+            }
+            eventType = parser.next();
+        }
+
+        return themes;
+    }
+
+    public static void setThemeStyle(XmlRenderTheme theme, String id) {
+        theme.setMenuCallback(themestyle -> {
+            String themeId = id.isEmpty() ? themestyle.getDefaultValue() : id;
+            XmlRenderThemeStyleLayer baseLayer = themestyle.getLayer(themeId);
+            if (baseLayer == null) {
+                return null;
+            }
+
+            // add the categories from overlays
+            Set<String> result = baseLayer.getCategories();
+            for (XmlRenderThemeStyleLayer overlay : baseLayer.getOverlays()) {
+                result.addAll(overlay.getCategories());
+            }
+
+            return result;
+        });
+    }
+
+
+    private static List<File> findFilesWithExtension(List<File> foundFiles, File[] filesArray, String ext) {
+        if (filesArray == null) {
+            return foundFiles;
+        }
+
+        for (File file : filesArray) {
+            if (file.isDirectory()) {
+                findFilesWithExtension(foundFiles,file.listFiles(path ->
+                        (path.isDirectory() || path.getName().toLowerCase().endsWith(ext))), ext);
+            } else if (file.getName().toLowerCase().endsWith(ext)) {
+                foundFiles.add(file);
+            }
+        }
+        return foundFiles;
+    }
+
+
+    private static boolean isMapsforgeBinaryOSM(File file) {
+        // https://github.com/mapsforge/mapsforge/blob/master/docs/Specification-Binary-Map-File.md
+        int magicByteSize = 20;
+        String magicByteString = "mapsforge binary OSM";
+
+        byte[] buffer = new byte[magicByteSize];
+        try (InputStream is = new FileInputStream(file.getAbsolutePath())) {
+            is.read(buffer);
+        } catch (IOException ignored) { }
+        return new String(buffer).contentEquals(magicByteString);
+    }
+
+    private static boolean isMapsforgeThemeXML(File file) {
+        String identifier = "http://mapsforge.org/renderTheme";
+        try (BufferedReader br = new BufferedReader(new FileReader(file))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                if (line.contains(identifier)) {
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            return false;
+        }
+        return false;
+    }
+}

--- a/app/src/main/java/fi/bitrite/android/ws/ui/util/UserMarkerClusterer.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/util/UserMarkerClusterer.java
@@ -159,7 +159,7 @@ public class UserMarkerClusterer extends RadiusMarkerClusterer {
             if (bucket < BUCKETS[0]) {
                 return String.valueOf(bucket);
             }
-            return String.valueOf(bucket) + "+";
+            return bucket + "+";
         }
 
         private class TextDrawable extends Drawable {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -98,7 +98,7 @@
     <string name="distance_unit_kilometers_short">km</string>
     <string name="distance_unit_miles_short">mi</string>
 
-    <string name="prefs_tile_source_title">Kartenstil</string>
+    <string name="prefs_online_map_source_title">Online-Kartenstil</string>
     <string name="prefs_tile_source_us_only">%1$s (nur USA)</string>
 
     <string name="prefs_message_refresh_interval_min_title">Aktualisierungsintervall für Nachrichten</string>
@@ -262,4 +262,8 @@
 
     <string name="invalid_api_key">Der Server hat die Anfrage abgewiesen. Bitte aktualisiere die App.\n(%1$s)</string>
     <string name="login_error_account_ip_temp_blocked">Zu viele Loginversuche. Dieses Konto ist zur Zeit gesperrt. Bitte versuche es später noch einmal.</string>
+    <string name="map_search_in_progress">Suche nach Offline-Karten</string>
+    <string name="no_offline_maps_found_title">Keine Offline-Karten gefunden</string>
+    <string name="open_map_provider_overview">Liste von Offline-Kartenanbietern</string>
+    <string name="no_offline_maps_found_message">Kopiere entpackte Offline-Karten nach <i>%1$s</i> und versuche es erneut.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -92,7 +92,7 @@
 
     <string name="prefs_distance_unit_title">Unidad de distancia</string>
     <string name="prefs_distance_unit_summary">Denunciar distancias en %1$s</string>
-    <string name="prefs_tile_source_title">Estilo de mapa</string>
+    <string name="prefs_online_map_source_title">Origen de mapa en línea</string>
     <string name="prefs_tile_source_us_only">%1$s (sólo EE.UU.)</string>
     <string name="distance_unit_kilometers_long">Kilómetros</string>
     <string name="distance_unit_miles_long">Millas</string>
@@ -248,4 +248,8 @@
 
     <string name="invalid_api_key">El servidor rechazó la solicitud. Por favor actualice la aplicación.\n(%1$s)</string>
     <string name="login_error_account_ip_temp_blocked">Demasiados intentos de inicio de sesión. Su cuenta está temporalmente bloqueada. Por favor, inténtelo de nuevo más tarde.</string>
+    <string name="open_map_provider_overview">Lista de proveedores de mapas fuera de línea</string>
+    <string name="no_offline_maps_found_title">No se han encontrado mapas fuera de línea</string>
+    <string name="no_offline_maps_found_message">Copie los datos del mapa fuera de línea descomprimidos en <i>%1$s</i> e inténtelo de nuevo.</string>
+    <string name="map_search_in_progress">Búsqueda de mapas fuera de línea</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -97,7 +97,7 @@
     <string name="distance_unit_kilometers_short">km</string>
     <string name="distance_unit_miles_short">mi</string>
 
-    <string name="prefs_tile_source_title">Style de la carte</string>
+    <string name="prefs_online_map_source_title">Source de la carte en ligne</string>
     <string name="prefs_tile_source_us_only">%1$s (É.-U. seulement)</string>
 
     <!-- Non-english speakers might prefer the default location to be over Africa, Europe & Central Asia. -->
@@ -254,4 +254,8 @@
 
     <string name="invalid_api_key">Le serveur a rejeté la demande. STP mettre à jour l\'application.\n(%1$s)</string>
     <string name="login_error_account_ip_temp_blocked">Trop de tentatives de connexion. Votre compte est temporairement bloqué. Veuillez réessayer plus tard.</string>
+    <string name="no_offline_maps_found_message">Copiez la carte hors ligne dans <i>%1$s</i> et réessayez.</string>
+    <string name="map_search_in_progress">Recherche de cartes hors ligne</string>
+    <string name="no_offline_maps_found_title">Aucune carte hors-ligne trouvée</string>
+    <string name="open_map_provider_overview">Liste des fournisseurs de cartes hors ligne</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,10 +102,15 @@
     <string name="distance_unit_kilometers_short_raw" translatable="false">km</string>
     <string name="distance_unit_miles_short_raw" translatable="false">mi</string>
 
-    <string name="prefs_tile_source_key" translatable="false">tile_source</string>
-    <string name="prefs_tile_source_title">Map style</string>
+    <string name="prefs_online_map_source_title">Online map source</string>
     <string name="prefs_tile_source_summary" translatable="false">%1$s</string>
     <string name="prefs_tile_source_us_only">%1$s (US only)</string>
+
+    <string name="prefs_offline_map_enabled" translatable="false">offline_map_enabled</string>
+    <string name="prefs_offline_map_selection" translatable="false">offline_map_selection</string>
+    <string name="prefs_offline_map_source_files" translatable="false">offline_map_source_files</string>
+    <string name="prefs_offline_theme_selection" translatable="false">offline_theme_selection</string>
+    <string name="prefs_offline_theme_source_files" translatable="false">offline_theme_source_files</string>
 
     <string name="prefs_message_refresh_interval_min_key" translatable="false">message_reload_interval_min</string>
     <string name="prefs_message_refresh_interval_min_title">Messages poll frequency</string>
@@ -274,4 +279,14 @@
     <string name="login_error_account_ip_temp_blocked">Too many login attempts. Your account is temporarily blocked. Please try again later.</string>
 
     <string name="notification_channel_messages_label" translatable="false">@string/title_fragment_messages</string>
+    <string name="prefs_online_map_source" translatable="false">prefs_online_map_source</string>
+    <string name="prefs_offline_maps_prefs_help_text" translatable="false">prefs_offline_maps_prefs_help_text</string>
+    <string name="prefs_offline_map_search" translatable="false">prefs_offline_map_search</string>
+    <string name="prefs_offline_map_prefer_installed_locales" translatable="false">prefs_offline_map_prefer_installed_locales</string>
+    <string name="map_search_in_progress">Searching for offline maps</string>
+    <string name="prefs_offline_map_theme_sources" translatable="false">prefs_offline_map_theme_sources</string>
+    <string name="prefs_offline_map_search_scope" translatable="false">prefs_offline_map_search_scope</string>
+    <string name="no_offline_maps_found_title">No offline maps found</string>
+    <string name="no_offline_maps_found_message">Copy unzipped offline map data to <i>%1$s</i> and try again.</string>
+    <string name="open_map_provider_overview">List of offline map providers</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -5,20 +5,35 @@ Reflect changes in `app/src/google/res/xml/preferences.xml`.
 
 -->
 <PreferenceScreen
-    xmlns:android="http://schemas.android.com/apk/res/android">
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <ListPreference
-        android:defaultValue="@string/prefs_distance_unit_default"
-        android:entries="@array/prefs_distance_unit_entries"
-        android:entryValues="@array/prefs_distance_unit_entry_values"
-        android:key="@string/prefs_distance_unit_key"
-        android:summary="@string/prefs_distance_unit_summary"
-        android:title="@string/prefs_distance_unit_title" />
+    <PreferenceCategory
+        android:title="Map settings" >
 
-    <ListPreference
-        android:key="@string/prefs_tile_source_key"
-        android:summary="@string/prefs_tile_source_summary"
-        android:title="@string/prefs_tile_source_title" />
+        <ListPreference
+            android:key="@string/prefs_online_map_source"
+            android:title="@string/prefs_online_map_source_title"
+            android:summary="@string/prefs_tile_source_summary" />
+
+        <SwitchPreference
+            android:key="@string/prefs_offline_map_enabled"
+            android:title="Use offline maps"
+            android:checked="false" />
+
+        <ListPreference
+            android:key="@string/prefs_offline_theme_selection"
+            android:title="Offline map style"
+            android:summary="@string/prefs_tile_source_summary" />
+
+        <MultiSelectListPreference
+            android:key="@string/prefs_offline_map_selection"
+            android:title="Offline map source"
+            app:isPreferenceVisible="false" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="Messaging">
 
     <fi.bitrite.android.ws.ui.preference.RefreshIntervalPreference
         android:defaultValue="@integer/prefs_message_refresh_interval_min_default"
@@ -26,11 +41,25 @@ Reflect changes in `app/src/google/res/xml/preferences.xml`.
         android:inputType="number"
         android:key="@string/prefs_message_refresh_interval_min_key"
         android:title="@string/prefs_message_refresh_interval_min_title" />
+    </PreferenceCategory>
 
-    <SwitchPreference
+    <PreferenceCategory
+        android:title="Other">
+
+        <ListPreference
+            android:defaultValue="@string/prefs_distance_unit_default"
+            android:entries="@array/prefs_distance_unit_entries"
+            android:entryValues="@array/prefs_distance_unit_entry_values"
+            android:key="@string/prefs_distance_unit_key"
+            android:summary="@string/prefs_distance_unit_summary"
+            android:title="@string/prefs_distance_unit_title" />
+
+        <SwitchPreference
         android:defaultValue="@bool/prefs_data_saver_mode_default"
         android:key="@string/prefs_data_saver_mode_key"
         android:title="@string/prefs_data_saver_mode_title"
         android:summary="@string/prefs_data_saver_mode_summary"/>
+
+    </PreferenceCategory>
 
 </PreferenceScreen>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.2'
         classpath 'com.saantiaguilera.securekeys:plugin:2.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 android.enableJetifier=true
 android.useAndroidX=true
-android.jetifier.blacklist = shadows-supportv4-4.3.jar
+android.jetifier.blacklist = shadows-supportv4-4.3.1.jar


### PR DESCRIPTION
This PR implements basic support for offline maps and would close #296 

**Make it work**
1. Download offline map data (maps and/or themes) from [one of these map providers](https://github.com/mapsforge/mapsforge/blob/master/docs/Mapsforge-Maps.md). I recommend OpenAndroMaps, as they also provide map themes.
2. Unzip if neccessary and copy into `/sdcard/Android/data/fi.bitrite.android.ws/files/`
3. You can now active offline maps and choose a theme (if installed) in the app settings.
4. All offline maps are activated automatically

**Future ideas and plans (not for this PR)**
- Option to choose map language (blocked until next release of OsmDroid, containing https://github.com/osmdroid/osmdroid/pull/1421)
- Option to manually activate/deactivate and sort offline maps
- Use deep links to install maps and themes from map providers
- Options for toggling map features like POIs etc
- Option to manually add more folders to search for map data, e.g. to reuse maps downloaded by Oruxmaps or Locus
- Add a help section into the app to explain how offline maps can be installed