### PR TITLE
Load large image in sidenav if connected to wifi

### DIFF
--- a/app/src/main/java/fi/bitrite/android/ws/ui/MainActivity.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/MainActivity.java
@@ -441,7 +441,7 @@ public class MainActivity extends AppCompatActivity implements HasAndroidInjecto
                             mLblFullname.setText(loggedInUser.fullname);
                             mLblUsername.setText(loggedInUser.username);
 
-                            String profilePhotoUrl = loggedInUser.profilePicture.getSmallUrl();
+                            String profilePhotoUrl = loggedInUser.profilePicture.getLargeUrl();
                             if (TextUtils.isEmpty(profilePhotoUrl)) {
                                 mImgUserPhoto.setImageResource(
                                         R.drawable.default_userinfo_profile);


### PR DESCRIPTION
The larger profile picture will be loaded if connected to wifi or
already cached.

Note: Since I have no API key yet, I wasn't able to test this PR myself. 