### PR TITLE
Propagate dispose() to nested disposable

### DIFF
--- a/app/src/main/java/fi/bitrite/android/ws/ui/AuthenticatorActivity.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/AuthenticatorActivity.java
@@ -236,7 +236,7 @@ public class AuthenticatorActivity extends AccountAuthenticatorFragmentActivity
      */
     @OnClick(R.id.auth_btn_forgot_password)
     public void forgotPassword() {
-        final String passwordResetPageUrl = getString(R.string.url_target_forgot_password);
+        final String passwordResetPageUrl = getString(R.string.url_website_base) + "/user/password";
         startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(passwordResetPageUrl)));
     }
 

--- a/app/src/main/java/fi/bitrite/android/ws/ui/UserFragment.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/UserFragment.java
@@ -49,7 +49,6 @@ import fi.bitrite.android.ws.repository.FavoriteRepository;
 import fi.bitrite.android.ws.repository.FeedbackRepository;
 import fi.bitrite.android.ws.repository.UserRepository;
 import fi.bitrite.android.ws.ui.listadapter.FeedbackListAdapter;
-import fi.bitrite.android.ws.util.GlobalInfo;
 import fi.bitrite.android.ws.util.Tools;
 import fi.bitrite.android.ws.util.WSGlide;
 import io.reactivex.Maybe;
@@ -358,8 +357,8 @@ public class UserFragment extends BaseFragment {
         }
     }
 
-    public void viewOnSite(@NonNull User user) {
-        String url = GlobalInfo.warmshowersBaseUrl + "/user/" + user.id;
+    private void viewOnSite(@NonNull User user) {
+        String url = getString(R.string.url_website_base) + "/user/" + user.id;
         Intent i = new Intent(Intent.ACTION_VIEW);
         i.setData(Uri.parse(url));
         startActivity(i);

--- a/app/src/main/java/fi/bitrite/android/ws/util/GlobalInfo.java
+++ b/app/src/main/java/fi/bitrite/android/ws/util/GlobalInfo.java
@@ -1,8 +1,0 @@
-package fi.bitrite.android.ws.util;
-
-/**
- * Provide basic info that may not be accessible any other way.
- */
-public class GlobalInfo {
-    public static final String warmshowersBaseUrl = "https://www.warmshowers.org";
-}

--- a/app/src/main/java/fi/bitrite/android/ws/util/UserRegionalCache.java
+++ b/app/src/main/java/fi/bitrite/android/ws/util/UserRegionalCache.java
@@ -14,6 +14,7 @@ import fi.bitrite.android.ws.di.AppScope;
 import fi.bitrite.android.ws.di.account.AccountScope;
 import fi.bitrite.android.ws.repository.UserRepository;
 import io.reactivex.Observable;
+import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
 
 /**
@@ -64,7 +65,7 @@ public class UserRegionalCache {
                             }));
                 }
 
-                Observable.mergeDelayError(observables)
+                Disposable d = Observable.mergeDelayError(observables)
                         .doOnComplete(() -> {
                             // We add one big (possibly overlapping) rather than several small
                             // unloaded areas.
@@ -79,6 +80,7 @@ public class UserRegionalCache {
                             }
                         })
                         .subscribe(emitter::onNext, emitter::onError, emitter::onComplete);
+                emitter.setDisposable(d);
             }).subscribeOn(Schedulers.computation());
         }
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -232,7 +232,7 @@
 
     <string name="remember_password">Passwort speichern?</string>
     <string name="button_text_forgot_password">Passwort vergessen?</string>
-    <string name="url_target_forgot_password">https://de.warmshowers.org/user/password</string>
+    <string name="url_website_base">https://de.warmshowers.org</string>
 
     <string name="content_description_your_avatar">Dein Avatar</string>
     <string name="content_description_avatar_of_var">Avatar von %s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -197,7 +197,7 @@
 
     <string name="remember_password">¿Guardar la contraseña?</string>
     <string name="button_text_forgot_password">¿Has olvidado la contraseña?</string>
-    <string name="url_target_forgot_password">https://es.warmshowers.org/user/password</string>
+    <string name="url_website_base">https://es.warmshowers.org</string>
 
     <string name="content_description_your_avatar">Tu foto de perfil</string>
     <string name="content_description_avatar_of_var">Foto de perfil de %s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -204,7 +204,7 @@
 
     <string name="remember_password">Enregistrer le mot de passe?</string>
     <string name="button_text_forgot_password">Mot de passe oublié?</string>
-    <string name="url_target_forgot_password">https://fr.warmshowers.org/user/password</string>
+    <string name="url_website_base">https://fr.warmshowers.org</string>
 
     <string name="content_description_your_avatar">Votre photo de profil</string>
     <string name="content_description_avatar_of_var">Photo du profil de %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -242,7 +242,7 @@
 
     <string name="remember_password">Remember password?</string>
     <string name="button_text_forgot_password">Forgot your password?</string>
-    <string name="url_target_forgot_password">https://www.warmshowers.org/user/password</string>
+    <string name="url_website_base">https://www.warmshowers.org</string>
 
     <string name="content_description_your_avatar">Your avatar</string>
     <string name="content_description_avatar_of_var">%s’s avatar</string>

--- a/app/src/test/java/fi/bitrite/android/ws/WSTest.java
+++ b/app/src/test/java/fi/bitrite/android/ws/WSTest.java
@@ -1,0 +1,71 @@
+package fi.bitrite.android.ws;
+
+import org.robolectric.Robolectric;
+import org.robolectric.RuntimeEnvironment;
+
+import fi.bitrite.android.ws.auth.AccountHelper;
+import fi.bitrite.android.ws.di.DaggerTestAppComponent;
+import fi.bitrite.android.ws.di.TestAppComponent;
+import io.reactivex.plugins.RxJavaPlugins;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Helper class with useful functions that are used in several tests.
+ */
+public class WSTest {
+    private static final TestAppComponent mAppComponent;
+    static {
+        WSAndroidApplication app = (WSAndroidApplication) RuntimeEnvironment.application;
+
+        mAppComponent = DaggerTestAppComponent.builder()
+                .application(app)
+                .build();
+        mAppComponent.inject(app);
+    }
+
+    private static AccountHelper mAccountHelper;
+
+    private WSTest() {}
+
+    static public TestAppComponent appComponent() {
+        return mAppComponent;
+    }
+
+    static public AccountHelper accountHelper() {
+        if (mAccountHelper == null) {
+            mAccountHelper = new AccountHelper(
+                    mAppComponent.getAccountManager(),
+                    mAppComponent.getAccountComponentManager());
+        }
+        return mAccountHelper;
+    }
+
+    static public UncaughtRxExceptionHelper createUncaughtRxExceptionHelper() {
+        UncaughtRxExceptionHelper uncaughtRxExceptionHelper = new UncaughtRxExceptionHelper();
+        RxJavaPlugins.setErrorHandler(e -> uncaughtRxExceptionHelper.throwable = e);
+        return uncaughtRxExceptionHelper;
+    }
+
+    public static class UncaughtRxExceptionHelper {
+        public Throwable throwable;
+
+        public void assertNoException() {
+            assertThat(throwable).isNull();
+        }
+    }
+
+    public static void flush() {
+        Robolectric.flushBackgroundThreadScheduler();
+        Robolectric.flushForegroundThreadScheduler();
+    }
+
+    public static void sleepAndFlush(int millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            // Ignore.
+        }
+        flush();
+    }
+}

--- a/app/src/test/java/fi/bitrite/android/ws/auth/AccountHelper.java
+++ b/app/src/test/java/fi/bitrite/android/ws/auth/AccountHelper.java
@@ -1,0 +1,36 @@
+package fi.bitrite.android.ws.auth;
+
+import android.accounts.Account;
+
+import fi.bitrite.android.ws.di.account.AccountComponentManager;
+import fi.bitrite.android.ws.di.account.TestAccountComponent;
+
+/**
+ * Helper class to set up mock accounts. Use through {@link fi.bitrite.android.ws.WSTest}.
+ */
+public class AccountHelper {
+    public final static AuthData DEFAULT_AUTH_DATA = new AuthData(
+            new Account("mockUser", "mockAccountType"),
+            new AuthToken("mockAuthTokenName", "mockAuthTokenId"),
+            "mockCsrfToken");
+    public final static int DEFAULT_USERID = 1000;
+    public final static String DEFAULT_PASSWORD = "verySecure";
+
+    private final AccountManager mAccountManager;
+    private final AccountComponentManager mAccountComponentManager;
+
+    public AccountHelper(AccountManager accountManager,
+                         AccountComponentManager accountComponentManager) {
+        mAccountManager = accountManager;
+        mAccountComponentManager = accountComponentManager;
+    }
+
+    public TestAccountComponent createAccount() {
+        return createAccount(DEFAULT_AUTH_DATA, DEFAULT_USERID, DEFAULT_PASSWORD);
+
+    }
+    public TestAccountComponent createAccount(AuthData authData, int userId, String csrfToken) {
+        mAccountManager.updateOrCreateAccount(authData, userId, csrfToken);
+        return (TestAccountComponent) mAccountComponentManager.get(authData.account);
+    }
+}

--- a/app/src/test/java/fi/bitrite/android/ws/di/account/TestAccountComponent.java
+++ b/app/src/test/java/fi/bitrite/android/ws/di/account/TestAccountComponent.java
@@ -6,6 +6,7 @@ import dagger.BindsInstance;
 import dagger.Subcomponent;
 import dagger.android.AndroidInjectionModule;
 import fi.bitrite.android.ws.auth.AuthTest;
+import fi.bitrite.android.ws.util.UserRegionalCacheTest;
 
 @AccountScope
 @Subcomponent(modules = {
@@ -26,4 +27,5 @@ public interface TestAccountComponent extends AccountComponent {
     }
 
     void inject(AuthTest authTest);
+    void inject(UserRegionalCacheTest test);
 }

--- a/app/src/test/java/fi/bitrite/android/ws/util/UserRegionalCacheTest.java
+++ b/app/src/test/java/fi/bitrite/android/ws/util/UserRegionalCacheTest.java
@@ -1,0 +1,111 @@
+package fi.bitrite.android.ws.util;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osmdroid.util.BoundingBox;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import javax.inject.Inject;
+
+import fi.bitrite.android.ws.WSTest;
+import fi.bitrite.android.ws.shadow.ShadowAccountManager;
+import io.reactivex.disposables.Disposable;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(shadows={ShadowAccountManager.class})
+public class UserRegionalCacheTest {
+
+    @Inject MockWebServer mMockWebServer;
+    @Inject UserRegionalCache mUserRegionalCache;
+
+    @Before
+    public void setup() {
+        WSTest.accountHelper()
+                .createAccount()
+                .inject(this);
+    }
+
+    /**
+     * Verifies that no uncaught exception appears when the disposable returned from
+     * {@link UserRegionalCache#searchByLocation(BoundingBox)} is disposed when the internal call
+     * to the webservice is only failing later.
+     */
+    @Test
+    public void testSearchByLocationTimeoutOnDisposed() {
+        WSTest.UncaughtRxExceptionHelper uncaughtRxExceptionHelper =
+                WSTest.createUncaughtRxExceptionHelper();
+
+        final Lock lock = new ReentrantLock();
+        final AtomicBoolean requestStarted = new AtomicBoolean(false);
+        final AtomicBoolean requestServed = new AtomicBoolean(false);
+
+        mMockWebServer.setDispatcher(new Dispatcher() {
+
+            @Override
+            public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+                if (!request.getPath().equals("/services/rest/hosts/by_location")) {
+                    return new MockResponse()
+                            .setStatus("HTTP/1.1 500")
+                            .setBody("[\"Unhandled\"]");
+                }
+
+                requestStarted.set(true);
+                try {
+                    // Wait for the lock to be released. Then we are sure that the disposable is
+                    // disposed.
+                    lock.lock();
+
+                    return new MockResponse()
+                            .setStatus("HTTP/1.1 500")
+                            .setBody("[\"Mock error\"]");
+                } finally {
+                    requestServed.set(true);
+                    lock.unlock();
+                }
+            }
+        });
+
+        // Set up the request. Hold the lock to ensure the request not being served before the
+        // disposable is disposed.
+        try {
+            lock.lock();
+            Disposable disposable = mUserRegionalCache.searchByLocation(new BoundingBox(0, 3, 2, 1))
+                    .subscribe(
+                            searchResult -> fail("No result expected from disposed"),
+                            throwable -> fail("No error expected from disposed"));
+
+            for (int i = 0; i < 10; i++) {
+                if (requestStarted.get()) {
+                    break;
+                }
+                WSTest.sleepAndFlush(100);
+            }
+            assertThat(requestStarted.get()).isTrue();
+
+            disposable.dispose();
+        } finally {
+            lock.unlock();
+        }
+
+        // Now wait some time to verify that no uncaught exception shows up.
+        for (int i = 0; i < 10; ++i) {
+            WSTest.sleepAndFlush(100);
+        }
+        assertThat(requestServed.get()).isTrue();
+        uncaughtRxExceptionHelper.assertNoException();
+    }
+
+}


### PR DESCRIPTION
Fixes crashes due to unhandled Rx exceptions when the disposable returned from `UserRegionalCache#searchByLocation()` was disposed and only after that the nested disposable emitted an error.

There are probably more occurrences of this issue but this one has visible user impact.