### PR TITLE
Unconfirmed user messages

### DIFF
--- a/app/src/main/java/fi/bitrite/android/ws/api/helper/HttpErrorHelper.java
+++ b/app/src/main/java/fi/bitrite/android/ws/api/helper/HttpErrorHelper.java
@@ -2,13 +2,13 @@ package fi.bitrite.android.ws.api.helper;
 
 
 import android.content.Context;
-import androidx.annotation.StringRes;
 import android.widget.Toast;
 
 import org.json.JSONException;
 
 import java.io.IOException;
 
+import androidx.annotation.StringRes;
 import fi.bitrite.android.ws.R;
 import fi.bitrite.android.ws.util.Tools;
 import retrofit2.HttpException;
@@ -18,7 +18,14 @@ public class HttpErrorHelper {
     @StringRes
     public static int getErrorStringRes(Throwable throwable) {
         if (throwable instanceof HttpException) {
-            return R.string.http_server_access_failure;
+            HttpException httpError = (HttpException) throwable;
+            if (httpError.code() == 403) {
+                return R.string.access_denied;
+            } else if (httpError.code() >= 500) {
+                return R.string.internal_server_error;
+            } else {
+                return R.string.http_server_access_failure;
+            }
         } else if (throwable instanceof IOException) {
             return R.string.io_error;
         } else if (throwable instanceof JSONException) {

--- a/app/src/main/java/fi/bitrite/android/ws/repository/FeedbackRepository.java
+++ b/app/src/main/java/fi/bitrite/android/ws/repository/FeedbackRepository.java
@@ -17,6 +17,7 @@ import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.schedulers.Schedulers;
+import retrofit2.HttpException;
 
 /**
  * This repository is split into two parts. One lives in the account scope as we need access to its
@@ -114,7 +115,7 @@ public class FeedbackRepository {
 
                             return new LoadResult<>(LoadResult.Source.NETWORK, feedbacks);
                         } else {
-                            throw new Error(apiFeedbackResponse.errorBody().string());
+                            throw new HttpException(apiFeedbackResponse);
                         }
                     });
         }
@@ -131,7 +132,7 @@ public class FeedbackRepository {
                             body, relation, rating, yearWeMet, monthWeMet))
                     .flatMapCompletable(apiResponse -> {
                         if (!apiResponse.isSuccessful()) {
-                            throw new Error(apiResponse.errorBody().string());
+                            throw new HttpException(apiResponse);
                         }
 
                         markAsOld(recipientId);

--- a/app/src/main/java/fi/bitrite/android/ws/repository/MessageRepository.java
+++ b/app/src/main/java/fi/bitrite/android/ws/repository/MessageRepository.java
@@ -131,7 +131,7 @@ public class MessageRepository extends Repository<MessageThread> {
                     .filter(response -> {
                         // Throwing errors is not allowed in onSuccess().
                         if (!response.isSuccessful()) {
-                            throw new Exception(response.errorBody().string());
+                            throw new HttpException(response);
                         } else if (!response.body().isSuccessful) {
                             throw new Exception("Retreived an unsuccessful response.");
                         }
@@ -168,7 +168,7 @@ public class MessageRepository extends Repository<MessageThread> {
                                 });
                     }, throwable -> {
                         Log.e(WSAndroidApplication.TAG,
-                                "Could not chreate the thread: " + throwable.toString());
+                                "Could not create the thread: " + throwable.toString());
                         emitter.onError(throwable);
                     });
         }).subscribeOn(Schedulers.io());
@@ -183,13 +183,13 @@ public class MessageRepository extends Repository<MessageThread> {
             // Creates and saves a new message.
             MessageThread thread = getRaw(threadId);
             if (thread == null) {
-                throw new Error("The thread needs to already be in the cache.");
+                throw new Exception("The thread needs to already be in the cache.");
             }
 
             int id = getNextPendingMessageId(thread);
             int authorId = mLoggedInUserHelper.getId();
             if (authorId == -1) {
-                throw new Error("No currently logged in user.");
+                throw new Exception("No currently logged in user.");
             }
 
             // Creates a temporary message and saves it into the database. We need to clone the

--- a/app/src/main/java/fi/bitrite/android/ws/repository/MessageRepository.java
+++ b/app/src/main/java/fi/bitrite/android/ws/repository/MessageRepository.java
@@ -38,6 +38,7 @@ import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
+import retrofit2.HttpException;
 
 /**
  * Acts as a intermediate to return messages from the database and in the background re-fetching
@@ -98,7 +99,7 @@ public class MessageRepository extends Repository<MessageThread> {
                 .observeOn(Schedulers.io())
                 .flatMapCompletable(apiResponse -> {
                     if (!apiResponse.isSuccessful()) {
-                        throw new Error(apiResponse.errorBody().string());
+                        return Completable.error(new HttpException(apiResponse));
                     }
 
                     MessageThreadListResponse responseBody = apiResponse.body();
@@ -322,7 +323,7 @@ public class MessageRepository extends Repository<MessageThread> {
                 .subscribeOn(Schedulers.io())
                 .flatMap(apiResponse -> {
                     if (!apiResponse.isSuccessful()) {
-                        throw new Error(apiResponse.errorBody().string());
+                        throw new HttpException(apiResponse);
                     }
 
                     MessageThreadResponse apiThread = apiResponse.body();

--- a/app/src/main/java/fi/bitrite/android/ws/repository/UserRepository.java
+++ b/app/src/main/java/fi/bitrite/android/ws/repository/UserRepository.java
@@ -144,7 +144,7 @@ public class UserRepository {
                     .subscribeOn(Schedulers.io())
                     .map(apiResponse -> {
                         if (!apiResponse.isSuccessful()) {
-                            throw new Error(apiResponse.errorBody().string());
+                            throw new HttpException(apiResponse);
                         }
 
                         Collection<ApiUser> apiUsers = apiResponse.body().users.values();

--- a/app/src/main/java/fi/bitrite/android/ws/repository/UserRepository.java
+++ b/app/src/main/java/fi/bitrite/android/ws/repository/UserRepository.java
@@ -128,7 +128,7 @@ public class UserRepository {
                     .subscribeOn(Schedulers.io())
                     .map(apiUserResponse -> {
                         if (!apiUserResponse.isSuccessful()) {
-                            throw new Error(apiUserResponse.errorBody().string());
+                            throw new HttpException(apiUserResponse);
                         }
 
                         return new LoadResult<>(

--- a/app/src/main/java/fi/bitrite/android/ws/repository/UserRepository.java
+++ b/app/src/main/java/fi/bitrite/android/ws/repository/UserRepository.java
@@ -20,6 +20,7 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.schedulers.Schedulers;
+import retrofit2.HttpException;
 
 /**
  * This repository is split into two parts. One lives in the account scope as we need access to its
@@ -178,7 +179,7 @@ public class UserRepository {
                     .subscribeOn(Schedulers.io())
                     .map(apiResponse -> {
                         if (!apiResponse.isSuccessful()) {
-                            throw new Error(apiResponse.errorBody().string());
+                            throw new HttpException(apiResponse);
                         }
 
                         return apiResponse.body().users;

--- a/app/src/main/java/fi/bitrite/android/ws/ui/ContactUserFragment.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/ContactUserFragment.java
@@ -1,6 +1,9 @@
 package fi.bitrite.android.ws.ui;
 
 import android.os.Bundle;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -15,9 +18,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
@@ -134,15 +134,13 @@ public class ContactUserFragment extends BaseFragment {
                 .createThread(subject, message, recipients)
                 // We wait for the threadId to become available.
                 .filter(threadId -> threadId != MessageRepository.STATUS_NEW_THREAD_ID_NOT_YET_KNOWN)
-                .subscribe(
-                        threadId -> mLastMessageSendResult.onNext(new MessageSendResult(threadId)),
+                .subscribe(threadId -> mLastMessageSendResult.onNext(new MessageSendResult(threadId)),
                         throwable -> {
-                            Log.d(WSAndroidApplication.TAG,
+                            Log.e(WSAndroidApplication.TAG,
                                     "Failed to create a new message thread: "
                                     + throwable.getMessage());
                             mLastMessageSendResult.onNext(new MessageSendResult(throwable));
-                        }
-                );
+                        });
     }
 
     @Override

--- a/app/src/main/java/fi/bitrite/android/ws/ui/ContactUserFragment.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/ContactUserFragment.java
@@ -1,9 +1,6 @@
 package fi.bitrite.android.ws.ui;
 
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -12,18 +9,21 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import java.util.Collections;
 import java.util.List;
 
 import javax.inject.Inject;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import fi.bitrite.android.ws.R;
 import fi.bitrite.android.ws.WSAndroidApplication;
+import fi.bitrite.android.ws.api.helper.HttpErrorHelper;
 import fi.bitrite.android.ws.model.SimpleUser;
 import fi.bitrite.android.ws.repository.MessageRepository;
 import fi.bitrite.android.ws.ui.util.DialogHelper;
@@ -109,8 +109,10 @@ public class ContactUserFragment extends BaseFragment {
                             navigationController.navigateToMessageThreads();
                         }
                     } else {
-                        Toast.makeText(getContext(), R.string.message_thread_create_failed,
-                                Toast.LENGTH_LONG).show();
+                        Log.d(WSAndroidApplication.TAG,
+                                "Failed to create a new message thread: "
+                                + result.throwable.getMessage());
+                        HttpErrorHelper.showErrorToast(getContext(), result.throwable);
                     }
                 }));
     }
@@ -135,13 +137,12 @@ public class ContactUserFragment extends BaseFragment {
                 .createThread(subject, message, recipients)
                 // We wait for the threadId to become available.
                 .filter(threadId -> threadId != MessageRepository.STATUS_NEW_THREAD_ID_NOT_YET_KNOWN)
-                .subscribe(threadId -> mLastMessageSendResult.onNext(new MessageSendResult(threadId)),
+                .subscribe(
+                        threadId -> mLastMessageSendResult.onNext(new MessageSendResult(threadId)),
                         throwable -> {
-                            Log.e(WSAndroidApplication.TAG,
-                                    "Failed to create a new message thread: "
-                                    + throwable.getMessage());
                             mLastMessageSendResult.onNext(new MessageSendResult(throwable));
-                        });
+                        }
+                );
     }
 
     @Override

--- a/app/src/main/java/fi/bitrite/android/ws/ui/ContactUserFragment.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/ContactUserFragment.java
@@ -109,9 +109,6 @@ public class ContactUserFragment extends BaseFragment {
                             navigationController.navigateToMessageThreads();
                         }
                     } else {
-                        Log.d(WSAndroidApplication.TAG,
-                                "Failed to create a new message thread: "
-                                + result.throwable.getMessage());
                         HttpErrorHelper.showErrorToast(getContext(), result.throwable);
                     }
                 }));
@@ -140,6 +137,9 @@ public class ContactUserFragment extends BaseFragment {
                 .subscribe(
                         threadId -> mLastMessageSendResult.onNext(new MessageSendResult(threadId)),
                         throwable -> {
+                            Log.d(WSAndroidApplication.TAG,
+                                    "Failed to create a new message thread: "
+                                    + throwable.getMessage());
                             mLastMessageSendResult.onNext(new MessageSendResult(throwable));
                         }
                 );

--- a/app/src/main/java/fi/bitrite/android/ws/ui/MapFragment.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/MapFragment.java
@@ -62,6 +62,7 @@ import butterknife.ButterKnife;
 import butterknife.OnClick;
 import butterknife.Unbinder;
 import fi.bitrite.android.ws.R;
+import fi.bitrite.android.ws.api.helper.HttpErrorHelper;
 import fi.bitrite.android.ws.api.response.UserSearchByLocationResponse;
 import fi.bitrite.android.ws.model.SimpleUser;
 import fi.bitrite.android.ws.model.User;
@@ -566,7 +567,7 @@ public class MapFragment extends BaseFragment {
                             }, throwable -> {
                                 // TODO(saemy): Error handling.
                                 Log.e(TAG, throwable.getMessage());
-                                sendMessage(R.string.http_server_access_failure);
+                                HttpErrorHelper.showErrorToast(getContext(), throwable);
                             }));
         }
 

--- a/app/src/main/java/fi/bitrite/android/ws/ui/MessageThreadFragment.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/MessageThreadFragment.java
@@ -21,6 +21,7 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import fi.bitrite.android.ws.R;
+import fi.bitrite.android.ws.api.helper.HttpErrorHelper;
 import fi.bitrite.android.ws.repository.MessageRepository;
 import fi.bitrite.android.ws.repository.UserRepository;
 import fi.bitrite.android.ws.ui.listadapter.MessageListAdapter;
@@ -117,9 +118,7 @@ public class MessageThreadFragment extends BaseFragment {
                     if (result.throwable != null) {
                         // This should not happen, if there is no network connection we schedule
                         // sending the message for when it is back.
-                        Toast.makeText(getContext(), R.string.message_send_failed,
-                                Toast.LENGTH_LONG)
-                                .show();
+                        HttpErrorHelper.showErrorToast(getContext(), result.throwable);
                     } else {
                         mEdtNewMessage.setText("");
                     }

--- a/app/src/main/java/fi/bitrite/android/ws/ui/MessageThreadsFragment.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/MessageThreadsFragment.java
@@ -23,6 +23,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import fi.bitrite.android.ws.R;
+import fi.bitrite.android.ws.api.helper.HttpErrorHelper;
 import fi.bitrite.android.ws.model.MessageThread;
 import fi.bitrite.android.ws.repository.MessageRepository;
 import fi.bitrite.android.ws.repository.Resource;
@@ -165,9 +166,9 @@ public class MessageThreadsFragment extends BaseFragment {
                 mMessageRepository.reloadThreads()
                         .observeOn(AndroidSchedulers.mainThread())
                         .doOnEvent(t -> mSwipeRefresh.setRefreshing(false))
-                        .subscribe(() -> {}, throwable -> Toast.makeText(
-                                getContext(), R.string.messages_reload_failed, Toast.LENGTH_LONG)
-                                .show()));
+                        .subscribe(() -> {},
+                                throwable -> HttpErrorHelper.showErrorToast(getContext(),
+                                        throwable)));
     }
 
     @Override

--- a/app/src/main/java/fi/bitrite/android/ws/ui/MessageThreadsFragment.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/MessageThreadsFragment.java
@@ -6,7 +6,6 @@ import android.os.Parcelable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Toast;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/app/src/main/java/fi/bitrite/android/ws/ui/SearchFragment.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/SearchFragment.java
@@ -28,6 +28,7 @@ import butterknife.ButterKnife;
 import butterknife.OnItemClick;
 import fi.bitrite.android.ws.R;
 import fi.bitrite.android.ws.WSAndroidApplication;
+import fi.bitrite.android.ws.api.helper.HttpErrorHelper;
 import fi.bitrite.android.ws.model.SimpleUser;
 import fi.bitrite.android.ws.model.User;
 import fi.bitrite.android.ws.repository.Resource;
@@ -125,8 +126,8 @@ public class SearchFragment extends BaseFragment {
                     }
 
                     if (result.throwable != null) {
-                        // TODO(saemy): Better error message.
-                        DialogHelper.alert(getContext(), R.string.http_server_access_failure);
+                        DialogHelper.alert(getContext(),
+                                HttpErrorHelper.getErrorStringRes(result.throwable));
                     } else {
                         if (result.userIds.isEmpty()) {
                             DialogHelper.alert(getContext(), R.string.no_results);

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -225,7 +225,6 @@
     <string name="message_new_hint">Gib eine Nachricht ein</string>
     <string name="message_mark_unread">Als ungelesen markieren</string>
     <string name="message_mark_read">Als gelesen markieren</string>
-    <string name="message_send_failed">Fehler beim Senden der Nachricht.</string>
 
     <string name="remember_password">Passwort speichern?</string>
     <string name="button_text_forgot_password">Passwort vergessen?</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -222,9 +222,6 @@
     <string name="title_fragment_users">Gastgeber</string>
     <string name="title_fragment_filter_list">Gastgeber-Filter</string>
 
-    <string name="message_thread_create_failed">Fehler beim Erstellen eines neuen Chats.</string>
-    <string name="messages_reload_failed">Fehler beim Abrufen der Nachrichten.</string>
-
     <string name="message_new_hint">Gib eine Nachricht ein</string>
     <string name="message_mark_unread">Als ungelesen markieren</string>
     <string name="message_mark_read">Als gelesen markieren</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -227,8 +227,6 @@
     <string name="menu_goto_profile">Mostrar perfil</string>
     <string name="menu_goto_profiles">Mostrar perfiles</string>
     <string name="message_new_hint">Escriba un mensaje</string>
-    <string name="messages_reload_failed">Error al obtener mensajes.</string>
-    <string name="message_thread_create_failed">Error al crear una nueva conversación.</string>
     <string name="feedback_error_sending">El comentario no fue enviado.</string>
 
     <string name="unknown_location">Ubicación desconocida</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -223,7 +223,6 @@
     <string name="prefs_dev_simulate_no_network_title">Simular Sin Servicio</string>
     <string name="message_mark_read">Marcar como leído</string>
     <string name="message_mark_unread">Marcar como no leído</string>
-    <string name="message_send_failed">Fallo al enviar el mensaje.</string>
     <string name="menu_goto_profile">Mostrar perfil</string>
     <string name="menu_goto_profiles">Mostrar perfiles</string>
     <string name="message_new_hint">Escriba un mensaje</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -229,7 +229,6 @@
     <string name="prefs_dev_simulate_no_network_title">Simuler une absence de service</string>
     <string name="message_mark_read">Marque comme lue</string>
     <string name="message_mark_unread">Marquer comme non lu</string>
-    <string name="message_send_failed">Échec de l’envoi du message.</string>
     <string name="menu_goto_profile">Montre le profile</string>
     <string name="menu_goto_profiles">Afficher les profils</string>
     <string name="message_new_hint">Tapez un message</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -233,8 +233,6 @@
     <string name="menu_goto_profile">Montre le profile</string>
     <string name="menu_goto_profiles">Afficher les profils</string>
     <string name="message_new_hint">Tapez un message</string>
-    <string name="messages_reload_failed">Erreur lors de l\'obtention de messages.</string>
-    <string name="message_thread_create_failed">Erreur lors de la création d’une nouvelle conversation.</string>
     <string name="feedback_error_sending">L’envoi du commentaire a échoué.</string>
 
     <string name="unknown_location">Position inconnue</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -220,9 +220,6 @@
     <string name="title_fragment_users">Utenti</string>
     <string name="title_fragment_filter_list">Filtro Utenti</string>
 
-    <string name="message_thread_create_failed">Impossibile creare un nuovo thread di messaggi.</string>
-    <string name="messages_reload_failed">Impossibile ricaricare i messaggi.</string>
-
     <string name="message_new_hint">Scrivi un messaggio</string>
     <string name="message_mark_unread">Segna come non letto</string>
     <string name="message_mark_read">Segna come letto</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -223,7 +223,6 @@
     <string name="message_new_hint">Scrivi un messaggio</string>
     <string name="message_mark_unread">Segna come non letto</string>
     <string name="message_mark_read">Segna come letto</string>
-    <string name="message_send_failed">Impossibile inviare il messaggio.</string>
 
     <string name="remember_password">Memorizza la password?</string>
     <string name="button_text_forgot_password">Password dimenticata?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -235,7 +235,6 @@
     <string name="message_new_hint">Type a message</string>
     <string name="message_mark_unread">Mark unread</string>
     <string name="message_mark_read">Mark read</string>
-    <string name="message_send_failed">Failed to send the message.</string>
 
     <string name="remember_password">Remember password?</string>
     <string name="button_text_forgot_password">Forgot your password?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -232,9 +232,6 @@
     <string name="title_fragment_users">Users</string>
     <string name="title_fragment_filter_list">User Filters</string>
 
-    <string name="message_thread_create_failed">Failed to create a new message thread.</string>
-    <string name="messages_reload_failed">Failed to reload the messages.</string>
-
     <string name="message_new_hint">Type a message</string>
     <string name="message_mark_unread">Mark unread</string>
     <string name="message_mark_read">Mark read</string>
@@ -273,7 +270,7 @@
     <string name="invalid_api_key">The server rejected the request. Please update the app.\n(%1$s)</string>
     <string name="login_error_account_ip_temp_blocked">Too many login attempts. Your account is temporarily blocked. Please try again later.</string>
     <string name="access_denied">Access denied. Please check your email for account confirmation message.</string>
-    <string name="internal_server_error">Something on the server side went wrong, we are so sorry! Please try again later.</string>
+    <string name="internal_server_error">Oops... This is on us, sorry! Something has gone wrong on the server side. Please try again later.</string>
 
     <string name="notification_channel_messages_label" translatable="false">@string/title_fragment_messages</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -272,6 +272,8 @@
 
     <string name="invalid_api_key">The server rejected the request. Please update the app.\n(%1$s)</string>
     <string name="login_error_account_ip_temp_blocked">Too many login attempts. Your account is temporarily blocked. Please try again later.</string>
+    <string name="access_denied">Access denied. Please check your email for account confirmation message.</string>
+    <string name="internal_server_error">Something on the server side went wrong, we are so sorry! Please try again later.</string>
 
     <string name="notification_channel_messages_label" translatable="false">@string/title_fragment_messages</string>
 </resources>


### PR DESCRIPTION
When user creates an account the e-mail address they provided needs to be verified. Util they confirm, they can log in but they don't have access to most resources so the server returns 403 errors. I changed the code so that they get a message with some hints what is going on. This solves https://github.com/warmshowers/wsandroid/issues/327.

I tried (quite hard) to write tests for my changes, temporarily gave up though. I hope to come back to it later, by the time please give a look at what I have so far.

Unconfirmed user can send requests resulting in 403 when loading users to the _Map_, _Searching_ for specific users or checking _Messages_. I updated all these places. Thought also that we might consider instead sending a request to check permissions when user logs in for the first time on the device (seems for me more intuitive to fail before going further).

I added filtering to exception handling. It is based on http error codes, so that:
* `403 Forbidden` response results in returning `access_denied` string from the resources (added), mapped to
_Access denied. Please check your email for account confirmation message._ (proposition)
* `500 Internal server error` response results in returning `internal_server_error` string (added), mapped to
 _Oops... This is on us, sorry! Something has gone wrong on the server side. Please try again later._

Also:
* `message_thread_create_failed`, `messages_reload_failed` and `message_send_failed` are not used anywhere any more so I removed them

I was thinking of changing error handling, moving towards having one place where different exception types and http error codes are translated to messages and displayed, so that it is more uniform across that app and we could easily hook some more robust logging/analytics. So far I started to placed it in `HttpErrorHelper`. And I changed `Error`s to `HttpException`s where applicable so we could differentiate exception handling behavior based on ex type and error code.