### PR TITLE
Add user notification

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,11 +96,13 @@ ext {
     androidMaterialVersion = '1.3.0'
     androidSupportCompat = '28.0.0'
     androidxAppcompatVersion = '1.3.0'
+    androidxWorkVersion = '2.5.0'
 }
 
 dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"
     implementation "androidx.appcompat:appcompat-resources:$androidxAppcompatVersion"
+    implementation "androidx.work:work-runtime:$androidxWorkVersion"
     implementation "com.android.support:support-compat:$androidSupportCompat"
     implementation "com.google.android.material:material:$androidMaterialVersion"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     package="fi.bitrite.android.ws">
 
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
     <application
         android:name=".WSAndroidApplication"
         android:allowBackup="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,21 @@
         android:label="@string/app_name"
         android:theme="@style/wsAppTheme">
 
+        <receiver android:name=".BroadcastReceiver">
+            <intent-filter>
+                <!--
+                These broadcasts are listened for to setup sending a notification to the user
+                without having them to open the application first.
+                 -->
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+
+                <action android:name=".BroadcastReceiver.SNOOZE_NOTIFICATION" />
+                <action android:name=".BroadcastReceiver.CANCEL_NOTIFICATION" />
+            </intent-filter>
+        </receiver>
+
         <activity
             android:name=".ui.ActivityMovingOut"
             android:launchMode="singleTop">

--- a/app/src/main/java/fi/bitrite/android/ws/BroadcastReceiver.java
+++ b/app/src/main/java/fi/bitrite/android/ws/BroadcastReceiver.java
@@ -1,0 +1,37 @@
+package fi.bitrite.android.ws;
+
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import java.util.Objects;
+
+public class BroadcastReceiver extends android.content.BroadcastReceiver {
+    private static final String TAG = BroadcastReceiver.class.getCanonicalName();
+
+    public static final String ACTION_CANCEL_NOTIFICATION = "fi.bitrite.android.ws.cancelNotification";
+    public static final String ACTION_SNOOZE_NOTIFICATION = "fi.bitrite.android.ws.snoozeNotification";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        Log.d(TAG, "Received broadcast: " + (intent != null ? intent.getAction() : "null"));
+        if (intent == null) {
+            return;
+        }
+
+        // There is nothing to do for the following actions as the notification scheduler is
+        // implicitly set up in WSAndroidApplication before reaching here:
+        // - Intent.BOOT_COMPLETED
+        // - Intent.QUICKBOOT_POWERON
+        // - Intent.MY_PACKAGE_REPLACED
+
+        String action = Objects.requireNonNull(intent.getAction());
+        if (action.equalsIgnoreCase(ACTION_SNOOZE_NOTIFICATION)) {
+            NotificationScheduler notificationScheduler = new NotificationScheduler(context);
+            notificationScheduler.snoozeNotification();
+        } else if (action.equalsIgnoreCase(ACTION_CANCEL_NOTIFICATION)) {
+            NotificationScheduler notificationScheduler = new NotificationScheduler(context);
+            notificationScheduler.disableNotifications();
+        }
+    }
+}

--- a/app/src/main/java/fi/bitrite/android/ws/NotificationScheduler.java
+++ b/app/src/main/java/fi/bitrite/android/ws/NotificationScheduler.java
@@ -1,0 +1,87 @@
+package fi.bitrite.android.ws;
+
+import android.content.Context;
+import android.util.Log;
+
+import java.util.concurrent.TimeUnit;
+
+import androidx.work.ExistingPeriodicWorkPolicy;
+import androidx.work.PeriodicWorkRequest;
+import androidx.work.WorkManager;
+
+public class NotificationScheduler {
+    private final static String TAG = NotificationScheduler.class.getCanonicalName();
+    private final static String UNIQUE_WORK_NAME = "notification";
+
+    private final Context mContext;
+    private final Settings mSettings;
+    private final WorkManager mWorkManager;
+
+    public NotificationScheduler(Context context) {
+        mContext = context;
+        mSettings = new Settings(context);
+        mWorkManager = WorkManager.getInstance(context);
+    }
+
+    /**
+     * Register a work request with Android's work manager that checks every two hours whether to
+     * show a notification to the user. That work item is persisted even after application shutdown,
+     * device restart, ...
+     * After notifications got disabled (see {@link #disableNotifications()}) this function no
+     * longer registers any work request and just returns.
+     */
+    public void schedule() {
+        if (mSettings.getNextNotificationMs() == Long.MAX_VALUE) {
+            // The notifications got disabled.
+            Log.d(TAG, "Not scheduling any work as notifications are disabled");
+            return;
+        }
+
+        PeriodicWorkRequest notificationWorkRequest =
+                new PeriodicWorkRequest.Builder(NotificationWorker.class, 2, TimeUnit.HOURS)
+                        .setInitialDelay(3, TimeUnit.MINUTES)
+                        .build();
+
+        mWorkManager.enqueueUniquePeriodicWork(
+                UNIQUE_WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                notificationWorkRequest);
+        Log.d(TAG, "Scheduled notification worker");
+    }
+
+    /**
+     * Removes the currently shown notification and re-schedules it, applying a linear backoff
+     * strategy for the time between two notifications.
+     */
+    public void snoozeNotification() {
+        NotificationWorker.removeNotification(mContext);
+
+        // Have a cool down period of n ticks between showing a notification, where n is the number
+        // of times the notification got snoozed.
+        // We delay for 21 hours per tick to make the notification not appear at the same time of
+        // the day every time.
+        int delayTicks = mSettings.incAndGetNotificationSnoozeCount();
+        final int msPerHour = 60 * 60 * 1000;
+        int delayMs = delayTicks * 21 * msPerHour;
+
+        final int maxDelayMs = 7 * 24 * msPerHour; // 1 week
+        if (delayMs > maxDelayMs) {
+            delayMs = maxDelayMs;
+        }
+
+        mSettings.setNextNotificationMs(System.currentTimeMillis() + delayMs);
+        Log.d(TAG, String.format("Snoozed notification for %.2f days", delayMs / msPerHour / 24.0));
+    }
+
+    /**
+     * Disables the notification. No more notifications are shown after calling this function.
+     */
+    public void disableNotifications() {
+        NotificationWorker.removeNotification(mContext);
+
+        mSettings.setNextNotificationMs(Long.MAX_VALUE);
+        mWorkManager.cancelUniqueWork(UNIQUE_WORK_NAME);
+        Log.d(TAG, "Disabled notifications");
+    }
+}
+

--- a/app/src/main/java/fi/bitrite/android/ws/NotificationWorker.java
+++ b/app/src/main/java/fi/bitrite/android/ws/NotificationWorker.java
@@ -41,6 +41,17 @@ public class NotificationWorker extends Worker {
             return Result.success();
         }
 
+        showNotification(context);
+        Log.d(TAG, "Notification shown");
+
+        return Result.success();
+    }
+
+    /**
+     * Shows the notification
+     * @param context
+     */
+    public static void showNotification(Context context) {
         Intent intent = new Intent(context, ActivityMovingOut.class);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         PendingIntent clickPendingIntent = PendingIntent.getActivity(context, 0, intent, 0);
@@ -57,7 +68,8 @@ public class NotificationWorker extends Worker {
                         .setContentTitle(context.getString(R.string.moving_out_notification_title))
                         .setContentText(context.getString(R.string.moving_out_notification_text_short))
                         .setStyle(new NotificationCompat.BigTextStyle()
-                                .bigText(context.getString(R.string.moving_out_notification_text_long)))
+                                .bigText(context.getString(R.string.moving_out_notification_text_short) + ".\n"
+                                         + context.getString(R.string.moving_out_notification_text_long)))
                         .setOnlyAlertOnce(true)
                         .setContentIntent(clickPendingIntent)
                         .setDeleteIntent(snoozePendingIntent)
@@ -65,9 +77,6 @@ public class NotificationWorker extends Worker {
 
         NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
         notificationManager.notify(NOTIFICATION_ID, builder.build());
-        Log.d(TAG, "Notification shown");
-
-        return Result.success();
     }
 
     /**

--- a/app/src/main/java/fi/bitrite/android/ws/NotificationWorker.java
+++ b/app/src/main/java/fi/bitrite/android/ws/NotificationWorker.java
@@ -1,0 +1,82 @@
+package fi.bitrite.android.ws;
+
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+import fi.bitrite.android.ws.ui.ActivityMovingOut;
+
+public class NotificationWorker extends Worker {
+    private final static String TAG = NotificationScheduler.class.getCanonicalName();
+
+    private final static int NOTIFICATION_ID = 1;
+
+    public NotificationWorker(@NonNull Context context, @NonNull WorkerParameters params) {
+        super(context, params);
+    }
+
+    /**
+     * Shows a notification in case the current time is later than the minimum next notification
+     * time stamp.
+     * This function is idempotent in case a notification is already shown to the user.
+     */
+    @Override
+    @NonNull
+    public Result doWork() {
+        Context context = getApplicationContext();
+
+        Settings settings = new Settings(context);
+        long nextNotificationMs = settings.getNextNotificationMs();
+        if (System.currentTimeMillis() < nextNotificationMs) {
+            Log.d(TAG, String.format(
+                    "Notification cool down period not yet reached (current: %d, min: %d)",
+                    System.currentTimeMillis(),
+                    nextNotificationMs));
+            return Result.success();
+        }
+
+        Intent intent = new Intent(context, ActivityMovingOut.class);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        PendingIntent clickPendingIntent = PendingIntent.getActivity(context, 0, intent, 0);
+
+        Intent snoozeIntent = new Intent(context, BroadcastReceiver.class);
+        snoozeIntent.setAction(BroadcastReceiver.ACTION_SNOOZE_NOTIFICATION);
+        PendingIntent snoozePendingIntent = PendingIntent.getBroadcast(context, 0, snoozeIntent, 0);
+
+        NotificationCompat.Builder builder =
+                new NotificationCompat.Builder(
+                        context,
+                        WSAndroidApplication.NOTIFICATION_CHANNEL_ID)
+                        .setSmallIcon(R.drawable.ic_bicycle_white_24dp)
+                        .setContentTitle(context.getString(R.string.moving_out_notification_title))
+                        .setContentText(context.getString(R.string.moving_out_notification_text_short))
+                        .setStyle(new NotificationCompat.BigTextStyle()
+                                .bigText(context.getString(R.string.moving_out_notification_text_long)))
+                        .setOnlyAlertOnce(true)
+                        .setContentIntent(clickPendingIntent)
+                        .setDeleteIntent(snoozePendingIntent)
+                        .setAutoCancel(true);
+
+        NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+        notificationManager.notify(NOTIFICATION_ID, builder.build());
+        Log.d(TAG, "Notification shown");
+
+        return Result.success();
+    }
+
+    /**
+     * Removes the currently shown notification.
+     * @param context
+     */
+    public static void removeNotification(Context context) {
+        NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+        notificationManager.cancel(NOTIFICATION_ID);
+        Log.d(TAG, "Removed notification");
+    }
+}

--- a/app/src/main/java/fi/bitrite/android/ws/Settings.java
+++ b/app/src/main/java/fi/bitrite/android/ws/Settings.java
@@ -1,0 +1,46 @@
+package fi.bitrite.android.ws;
+
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+public class Settings {
+    private final SharedPreferences mSharedPreferences;
+
+    private final static String KEY_NEXT_NOTIFICATION = "nextNotification";
+    private final static String KEY_NOTIFICATION_SNOOZE_COUNT = "notificationSnoozeCount";
+
+    public Settings(Context context) {
+        mSharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+    }
+
+    /**
+     * Sets the earliest timestamp to show the next notification.
+     * @param nextNotificationMs
+     */
+    public void setNextNotificationMs(long nextNotificationMs) {
+        mSharedPreferences
+                .edit()
+                .putLong(KEY_NEXT_NOTIFICATION, nextNotificationMs)
+                .apply();
+    }
+
+    /**
+     * Returns the earliest timestamp to show the next notification.
+     * @return
+     */
+    public long getNextNotificationMs() {
+        return mSharedPreferences.getLong(KEY_NEXT_NOTIFICATION, 0);
+    }
+
+    public int incAndGetNotificationSnoozeCount() {
+        int notificationSnoozeCount =
+                mSharedPreferences.getInt(KEY_NOTIFICATION_SNOOZE_COUNT, 0) + 1;
+        mSharedPreferences
+                .edit()
+                .putInt(KEY_NOTIFICATION_SNOOZE_COUNT, notificationSnoozeCount)
+                .apply();
+        return notificationSnoozeCount;
+    }
+}

--- a/app/src/main/java/fi/bitrite/android/ws/WSAndroidApplication.java
+++ b/app/src/main/java/fi/bitrite/android/ws/WSAndroidApplication.java
@@ -1,15 +1,33 @@
 package fi.bitrite.android.ws;
 
 import android.app.Application;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.os.Build;
 import android.util.Log;
 
 public class WSAndroidApplication extends Application {
     private final static String TAG = WSAndroidApplication.class.getCanonicalName();
+
+    public final static String NOTIFICATION_CHANNEL_ID = "notifications";
 
     @Override
     public void onCreate() {
         super.onCreate();
 
         Log.d(TAG, "Application create");
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            // Newer Android versions require a notification channel for notifications to be shown.
+            NotificationChannel channel = new NotificationChannel(
+                    NOTIFICATION_CHANNEL_ID,
+                    "Notifications",
+                    NotificationManager.IMPORTANCE_DEFAULT);
+            NotificationManager notificationManager = getSystemService(NotificationManager.class);
+            notificationManager.createNotificationChannel(channel);
+        }
+
+        // Start scheduling notifications.
+        new NotificationScheduler(getApplicationContext()).schedule();
     }
 }

--- a/app/src/main/java/fi/bitrite/android/ws/ui/ActivityMovingOut.java
+++ b/app/src/main/java/fi/bitrite/android/ws/ui/ActivityMovingOut.java
@@ -13,6 +13,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.appcompat.app.AppCompatActivity;
+import fi.bitrite.android.ws.NotificationScheduler;
 import fi.bitrite.android.ws.R;
 
 /**
@@ -43,6 +44,9 @@ public class ActivityMovingOut extends AppCompatActivity {
                 findViewById(R.id.moving_out_what_to_do_title),
                 findViewById(R.id.moving_out_what_to_do_head),
                 findViewById(R.id.moving_out_what_to_do_expand_collapse));
+
+        // The user is looking at the app. No longer show any notifications after this.
+        new NotificationScheduler(this).disableNotifications();
     }
 
     private void makeExpandable(TextView body, TextView title, LinearLayout head, ImageButton expand) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -59,4 +59,7 @@
           <li>&nbsp;<a href="market://details?id=fi.bitrite.android.ws">Bewerte diese App</a>, damit sie mehr Aufmerksamkeit bekommt.</li>
         </ul>
     ]]></string>
+
+    <string name="moving_out_notification_text_short">Eine Mitteilung der ehemaligen Entwickler</string>
+    <string name="moving_out_notification_text_long">Lese was mit Warmshowers passiert.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -60,4 +60,7 @@
           <li>&nbsp;<a href="market://details?id=fi.bitrite.android.ws">Califica esta aplicación</a> para obtener más exposición.</li>
         </ul>
     ]]></string>
+
+    <string name="moving_out_notification_text_short">Un mensaje de los antiguos desarrolladores</string>
+    <string name="moving_out_notification_text_long">Lea lo que está sucediendo con Warmshowers.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -60,4 +60,7 @@
           <li>&nbsp;<a href="market://details?id=fi.bitrite.android.ws">Évalue cette application</a> pour qu\'elle reçoive plus d\'attention.</li>
         </ul>
     ]]></string>
+
+    <string name="moving_out_notification_text_short">Un message des anciens développeurs</string>
+    <string name="moving_out_notification_text_long">Lisez ce qui se passe avec Warmshowers.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -60,4 +60,7 @@
           <li>&nbsp;<a href="market://details?id=fi.bitrite.android.ws">Vota questa app</a> in modo che riceva più attenzione.</li>
         </ul>
     ]]></string>
+
+    <string name="moving_out_notification_text_short">Un messaggio dagli ex sviluppatori</string>
+    <string name="moving_out_notification_text_long">Leggi cosa sta succedendo con Warmshowers.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,4 +60,8 @@
           <li>&nbsp;<a href="market://details?id=fi.bitrite.android.ws">Rate this app</a> for it to get more attention.</li>
         </ul>
     ]]></string>
+
+    <string name="moving_out_notification_title" translatable="false">@string/moving_out_title</string>
+    <string name="moving_out_notification_text_short">A message from the former developers</string>
+    <string name="moving_out_notification_text_long">Read what\'s happening with Warmshowers.</string>
 </resources>


### PR DESCRIPTION
Adds a notification to the user to ask them to open the app and read our message.

The notification is repeatedly shown until the user eventually clicks it. However, the interval between showing notifications is increased each time the user swipes the message away. It starts at once per day, then once every second day, ..., and is max'ed out at once every week.